### PR TITLE
If there are more than one sql in a statemnet, it will not be able to…

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendResultSet.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendResultSet.java
@@ -151,6 +151,11 @@ public class DatabendResultSet extends AbstractDatabendResultSet
                     finished = true;
                 }
             });
+            for(;;){
+                if(this.future.isDone() || this.future.isCancelled()){
+                    break;
+                }
+            }
         }
 
         public void cancel()

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestBasicDriver.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestBasicDriver.java
@@ -146,4 +146,22 @@ public class TestBasicDriver
             Assert.assertTrue(e.getMessage().contains("Query failed"));
         }
     }
+
+    @Test(groups = {"IT"})
+    public void testMultiStatement()
+            throws SQLException
+    {
+        try (Connection connection = createConnection()) {
+            Statement statement = connection.createStatement();
+            statement.executeQuery("use test_basic_driver");
+            statement.executeQuery("show full columns from table1");
+            ResultSet r = statement.getResultSet();
+            r.next();
+            r.getObject(1);
+            connection.close();
+        }
+        finally {
+
+        }
+    }
 }


### PR DESCRIPTION
If multiple sql statements exist in a statement, errors may occur occasionally and the error rate is high. In this case, adding an asynchronous execution thread to wait for the completion of the next sql statement can solve this problem