### PR TITLE
Fix column type name error for DatabendRawType

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendColumnInfo.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendColumnInfo.java
@@ -226,7 +226,7 @@ public class DatabendColumnInfo {
     }
 
     public String getColumnTypeName() {
-        return type.toString();
+        return type.getDataType().getDisplayName();
     }
 
     public boolean isCurrency() {


### PR DESCRIPTION
`DatabendRawType` is a class object, and the `toString()` method does not get the type name of the object itself.