### PR TITLE
fix: setNull with \N

### DIFF
--- a/databend-jdbc/pom.xml
+++ b/databend-jdbc/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/databend-jdbc/src/main/java/com/databend/jdbc/AbstractDatabendResultSet.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/AbstractDatabendResultSet.java
@@ -1491,13 +1491,17 @@ abstract class AbstractDatabendResultSet implements ResultSet {
     @Override
     public String getNString(int columnIndex)
             throws SQLException {
-        throw new SQLFeatureNotSupportedException("getNString");
+        Object value = column(columnIndex);
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
     }
 
     @Override
     public String getNString(String columnLabel)
             throws SQLException {
-        throw new SQLFeatureNotSupportedException("getNString");
+        return getNString(columnIndex(columnLabel));
     }
 
     @Override

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendPreparedStatement.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendPreparedStatement.java
@@ -402,7 +402,9 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
     public void setNull(int i, int i1)
             throws SQLException {
         checkOpen();
-        batchInsertUtils.ifPresent(insertUtils -> insertUtils.setPlaceHolderValue(i, null));
+        // Databend uses \N as default null representation for csv and tsv format
+        // https://github.com/datafuselabs/databend/pull/6453
+        batchInsertUtils.ifPresent(insertUtils -> insertUtils.setPlaceHolderValue(i, "\\N"));
     }
 
     @Override

--- a/databend-jdbc/src/main/java/com/databend/jdbc/parser/BatchInsertUtils.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/parser/BatchInsertUtils.java
@@ -2,6 +2,7 @@ package com.databend.jdbc.parser;
 
 import de.siegmar.fastcsv.writer.CsvWriter;
 import de.siegmar.fastcsv.writer.LineDelimiter;
+import de.siegmar.fastcsv.writer.QuoteStrategy;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -100,7 +101,14 @@ public class BatchInsertUtils {
     }
 
     public File saveBatchToCSV(List<String[]> values, File file) {
-        int rowSize = values.get(0).length;
+        int rowSize = 0;
+        for (String[] row : values) {
+            if (row != null) {
+                rowSize = row.length;
+                break;
+            }
+            throw new RuntimeException("batch values is empty");
+        }
         // save values to csv file
         try (FileWriter pw = new FileWriter(file)) {
             CsvWriter w = CsvWriter.builder().quoteCharacter('"').lineDelimiter(LineDelimiter.LF).build(pw);

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestPrepareStatement.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestPrepareStatement.java
@@ -54,7 +54,7 @@ public class TestPrepareStatement {
         ps.setInt(1, 1);
         ps.setString(2, "a");
         ps.addBatch();
-        ps.setInt(1, 3);
+        ps.setInt(1, 2);
         ps.setString(2, "b");
         ps.addBatch();
         System.out.println("execute batch insert");
@@ -71,6 +71,36 @@ public class TestPrepareStatement {
         while (r.next()) {
             System.out.println(r.getInt(1));
             System.out.println(r.getString(2));
+        }
+    }
+
+    @Test(groups = "IT")
+    public void TestBatchInsertWithNULL() throws SQLException {
+        Connection c = createConnection();
+        c.setAutoCommit(false);
+
+        PreparedStatement ps = c.prepareStatement("insert into test_prepare_statement values");
+        ps.setInt(1, 1);
+        ps.setString(2, "");
+        ps.addBatch();
+        ps.setInt(1, 2);
+        ps.setNull(2, Types.NULL);
+        ps.addBatch();
+        System.out.println("execute batch insert");
+        int[] ans = ps.executeBatch();
+        Assert.assertEquals(ans.length, 2);
+        Assert.assertEquals(ans[0], 1);
+        Assert.assertEquals(ans[1], 1);
+        Statement statement = c.createStatement();
+
+        System.out.println("execute select");
+        statement.execute("SELECT * from test_prepare_statement");
+        ResultSet r = statement.getResultSet();
+
+        while (r.next()) {
+            System.out.println(r.getInt(1));
+            //TODO(hantmac): need use real NULL type
+            Assert.assertEquals(r.getNString(2), "NULL");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Databend use `\N` as default null representation for csv and tsv format, which fixes https://github.com/datafuselabs/databend/issues/5586.

So we make `setNull` with `\N`.