### PR TITLE
fix: resultSetMetadata get decimal column

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendColumnInfo.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendColumnInfo.java
@@ -1,5 +1,6 @@
 package com.databend.jdbc;
 
+import com.databend.client.data.DatabendDataType;
 import com.databend.client.data.DatabendRawType;
 import com.databend.client.data.DatabendTypes;
 import com.google.common.base.Preconditions;
@@ -60,10 +61,10 @@ public class DatabendColumnInfo {
     }
 
     public static void setTypeInfo(Builder builder, DatabendRawType type) {
-        builder.setColumnType(getType(type));
+        builder.setColumnType(type.getDataType().getSqlType());
         boolean isNullable = type.isNullable();
         builder.setNullable(isNullable ? Nullable.NULLABLE : Nullable.NO_NULLS);
-        switch (type.getType()) {
+        switch (type.getDataType().getDisplayName()) {
             case DatabendTypes.BOOLEAN:
                 builder.setColumnDisplaySize(5);
                 break;
@@ -151,62 +152,18 @@ public class DatabendColumnInfo {
                 builder.setPrecision(TIMESTAMP_MAX);
                 builder.setColumnDisplaySize(TIMESTAMP_MAX);
                 break;
-
+            case DatabendTypes.DECIMAL:
+                builder.setSigned(true);
+                builder.setScale(type.getDecimalDigits());
+                builder.setPrecision(type.getColumnSize());
+                builder.setColumnDisplaySize(type.getColumnSize());
+                break;
         }
 
     }
 
     public static Builder newBuilder(String name, DatabendRawType type) {
-        return (new Builder()).setColumnName(name).setColumnType(getType(type));
-    }
-
-    private static int getType(DatabendRawType type) {
-        if (type == null) {
-            return java.sql.Types.NULL;
-        }
-//        if (type.isNullable()) {
-//            return getType(type.getInner());
-//        }
-        switch (type.getType().toLowerCase(Locale.US)) {
-            case DatabendTypes.BOOLEAN:
-                return java.sql.Types.BOOLEAN;
-            case DatabendTypes.UINT8:
-                return java.sql.Types.TINYINT;
-            case DatabendTypes.INT8:
-                return java.sql.Types.TINYINT;
-            case DatabendTypes.UINT16:
-                return java.sql.Types.SMALLINT;
-            case DatabendTypes.INT16:
-                return java.sql.Types.SMALLINT;
-            case DatabendTypes.UINT32:
-                return java.sql.Types.INTEGER;
-            case DatabendTypes.INT32:
-                return java.sql.Types.INTEGER;
-            case DatabendTypes.UINT64:
-                return java.sql.Types.BIGINT;
-            case DatabendTypes.INT64:
-                return java.sql.Types.BIGINT;
-            case DatabendTypes.FLOAT32:
-                return java.sql.Types.REAL;
-            case DatabendTypes.FLOAT64:
-                return java.sql.Types.DOUBLE;
-            case DatabendTypes.STRING:
-                return java.sql.Types.VARCHAR;
-            case DatabendTypes.DATE:
-                return java.sql.Types.DATE;
-            case DatabendTypes.DATETIME:
-                return java.sql.Types.TIMESTAMP;
-            case DatabendTypes.DATETIME64:
-                return java.sql.Types.TIMESTAMP;
-            case DatabendTypes.TIMESTAMP:
-                return java.sql.Types.TIMESTAMP;
-            case DatabendTypes.ARRAY:
-                return java.sql.Types.ARRAY;
-            case DatabendTypes.DECIMAL:
-                return java.sql.Types.DECIMAL;
-            default:
-                return Types.JAVA_OBJECT;
-        }
+        return (new Builder()).setColumnName(name).setColumnType(type.getDataType().getSqlType());
     }
 
     public int getColumnType() {

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendResultSetMetaData.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendResultSetMetaData.java
@@ -12,17 +12,14 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.List;
 
-public class DatabendResultSetMetaData implements ResultSetMetaData
-{
+public class DatabendResultSetMetaData implements ResultSetMetaData {
     private final List<DatabendColumnInfo> databendColumnInfo;
 
-    DatabendResultSetMetaData(List<DatabendColumnInfo> databendColumnInfo)
-    {
+    DatabendResultSetMetaData(List<DatabendColumnInfo> databendColumnInfo) {
         this.databendColumnInfo = databendColumnInfo;
     }
 
-    static String getType(int type)
-    {
+    static String getType(int type) {
         // see javax.sql.rowset.RowSetMetaDataImpl
         switch (type) {
             case Types.NUMERIC:
@@ -68,8 +65,7 @@ public class DatabendResultSetMetaData implements ResultSetMetaData
 
     @Override
     public int getColumnCount()
-            throws SQLException
-    {
+            throws SQLException {
         if (this.databendColumnInfo == null) {
             return 0;
         }
@@ -78,36 +74,31 @@ public class DatabendResultSetMetaData implements ResultSetMetaData
 
     @Override
     public boolean isAutoIncrement(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return false;
     }
 
     @Override
     public boolean isCaseSensitive(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return false;
     }
 
     @Override
     public boolean isSearchable(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return true;
     }
 
     @Override
     public boolean isCurrency(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return false;
     }
 
     @Override
     public int isNullable(int i)
-            throws SQLException
-    {
+            throws SQLException {
         DatabendColumnInfo.Nullable nullable = column(i).getNullable();
         switch (nullable) {
             case NO_NULLS:
@@ -122,126 +113,108 @@ public class DatabendResultSetMetaData implements ResultSetMetaData
 
     @Override
     public boolean isSigned(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).isSigned();
     }
 
     @Override
     public int getColumnDisplaySize(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getColumnDisplaySize();
     }
 
     @Override
     public String getColumnLabel(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getColumnLabel();
     }
 
     @Override
     public String getColumnName(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getColumnName();
     }
 
     @Override
     public String getSchemaName(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getSchemaName();
     }
 
     @Override
     public int getPrecision(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getPrecision();
     }
 
     @Override
     public int getScale(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getScale();
     }
 
     @Override
     public String getTableName(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getTableName();
     }
 
     @Override
     public String getCatalogName(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getCatalogName();
     }
 
     @Override
     public int getColumnType(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getColumnType();
     }
 
     @Override
     public String getColumnTypeName(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return column(i).getColumnTypeName();
     }
 
     @Override
     public boolean isReadOnly(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return true;
     }
 
     @Override
     public boolean isWritable(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return false;
     }
 
     @Override
     public boolean isDefinitelyWritable(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return false;
     }
 
     @Override
     public String getColumnClassName(int i)
-            throws SQLException
-    {
+            throws SQLException {
         return getType(column(i).getColumnType());
     }
 
     @Override
     public <T> T unwrap(Class<T> aClass)
-            throws SQLException
-    {
+            throws SQLException {
         return null;
     }
 
     @Override
     public boolean isWrapperFor(Class<?> aClass)
-            throws SQLException
-    {
+            throws SQLException {
         return false;
     }
 
     private DatabendColumnInfo column(int column)
-            throws SQLException
-    {
+            throws SQLException {
         if ((column <= 0) || (column > this.databendColumnInfo.size())) {
             throw new SQLException("Invalid column index: " + column);
         }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
@@ -107,13 +107,8 @@ public class TestDatabendDatabaseMetaData {
     public void testGetTables() throws Exception {
         try (Connection connection = createConnection()) {
             DatabaseMetaData metaData = connection.getMetaData();
-            try (ResultSet rs = metaData.getColumns("default", "default", "ttt", null)) {
-//                assertTableMetadata(rs);
-                ResultSetMetaData me = rs.getMetaData();
-                int i = me.getColumnType(1);
-                String s = me.getColumnTypeName(1);
-                System.out.println(i);
-                System.out.println(s);
+            try (ResultSet rs = connection.getMetaData().getTables(null, null, null, null)) {
+                assertTableMetadata(rs);
             }
         }
     }
@@ -173,7 +168,7 @@ public class TestDatabendDatabaseMetaData {
     @Test(groups = {"IT"})
     public void testGetColumnTypesBySelectEmpty() throws Exception {
         try (Connection connection = createConnection()) {
-            ResultSet rs = connection.createStatement().executeQuery("select * from test_column_meta");
+            ResultSet rs = connection.createStatement().executeQuery("select * from test_column_meta where 1=2");
             ResultSetMetaData metaData = rs.getMetaData();
             assertEquals(metaData.getColumnCount(), 17);
             for (int i = 1; i <= metaData.getColumnCount(); i++) {


### PR DESCRIPTION
Fix bug when `rs.getMetaData().getColumnType` for decimal(x,y) type failed.