### PR TITLE
fix: insert into single data then close query auto

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendStatement.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendStatement.java
@@ -202,7 +202,8 @@ public class DatabendStatement implements Statement {
                 QueryResults results = client.getResults();
                 List<List<Object>> data = results.getData();
                 List<QueryRowField> schema = results.getSchema();
-                if ((data == null || data.isEmpty()) && (schema == null || schema.isEmpty())) {
+//                if ((data == null || data.isEmpty()) && (schema == null || schema.isEmpty())) {
+                if (data == null || data.isEmpty()) {
                     client.advance();
                 } else {
                     break;

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendStatement.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendStatement.java
@@ -201,8 +201,7 @@ public class DatabendStatement implements Statement {
             while (client.hasNext()) {
                 QueryResults results = client.getResults();
                 List<List<Object>> data = results.getData();
-                List<QueryRowField> schema = results.getSchema();
-//                if ((data == null || data.isEmpty()) && (schema == null || schema.isEmpty())) {
+//                List<QueryRowField> schema = results.getSchema();
                 if (data == null || data.isEmpty()) {
                     client.advance();
                 } else {


### PR DESCRIPTION
Because `insert into` single data will return non-empty `schema` field, this cause `final` api not called. 
![image](https://github.com/datafuselabs/databend-jdbc/assets/7600925/c545bed5-2e68-40a9-a565-37ce2b6745b7)
