### PR TITLE
Fix getDatabaseMajorVersion & getDatabaseMinorVersion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,12 @@ jobs:
           - 9000:9000
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDatabaseMetaData.java
@@ -1333,14 +1333,9 @@ public class DatabendDatabaseMetaData implements DatabaseMetaData {
     public int getDatabaseMajorVersion()
             throws SQLException {
         String version = getDatabaseProductVersion();
-        // split by empty space
-        String[] versionArray = version.split(" ");
-        if (versionArray.length < 2) {
-            return -1;
-        }
         // regex matching v%d.%d.%d
         Pattern pattern = Pattern.compile("v(\\d+)\\.(\\d+)\\.(\\d+)");
-        Matcher matcher = pattern.matcher(versionArray[1]);
+        Matcher matcher = pattern.matcher(version);
         if (matcher.find()) {
             return 10 * Integer.parseInt(matcher.group(1)) + Integer.parseInt(matcher.group(2));
         }
@@ -1352,14 +1347,9 @@ public class DatabendDatabaseMetaData implements DatabaseMetaData {
     public int getDatabaseMinorVersion()
             throws SQLException {
         String version = getDatabaseProductVersion();
-        // split by empty space
-        String[] versionArray = version.split(" ");
-        if (versionArray.length < 2) {
-            return -1;
-        }
         // regex matching v%d.%d.%d
         Pattern pattern = Pattern.compile("v(\\d+)\\.(\\d+)\\.(\\d+)");
-        Matcher matcher = pattern.matcher(versionArray[1]);
+        Matcher matcher = pattern.matcher(version);
         if (matcher.find()) {
             return Integer.parseInt(matcher.group(3));
         }

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDatabaseMetaData.java
@@ -1440,7 +1440,7 @@ public class DatabendDatabaseMetaData implements DatabaseMetaData {
                 " name as FUNCTION_NAME, " +
                 " description as REMARKS, " +
                 " 1 as FUNCTION_TYPE, " +
-                " name as SPECIFIC_NAME" +
+                " name as SPECIFIC_NAME " +
                 "FROM system.functions");
         List<String> filters = new ArrayList<>();
         optionalStringLikeFilter(filters, "function_name", functionNamePattern);

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
@@ -86,14 +86,23 @@ public class TestDatabendDatabaseMetaData {
     }
 
     @Test(groups = {"IT"})
-    public void testGetDatabaseProductVersion()
+    public void testGetDatabaseProductName()
             throws Exception {
         try (Connection connection = createConnection()) {
             DatabaseMetaData metaData = connection.getMetaData();
             assertEquals(metaData.getDatabaseProductName(), "Databend");
-            StringBuilder sb = new StringBuilder();
-            sb.append(metaData.getDatabaseMinorVersion());
-            Assert.assertTrue(metaData.getDatabaseProductVersion().contains(sb.toString()));
+        }
+    }
+
+    @Test(groups = {"IT"})
+    public void testGetDatabaseProductVersion()
+            throws Exception {
+        try (Connection connection = createConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            float majorVersion = (float)metaData.getDatabaseMajorVersion() / 10;
+            int minorVersion = metaData.getDatabaseMinorVersion();
+            String checkVersion = String.format("v%.1f.%d", majorVersion, minorVersion);
+            Assert.assertTrue(metaData.getDatabaseProductVersion().contains(checkVersion));
         }
     }
 

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
@@ -261,4 +261,32 @@ public class TestDatabendDatabaseMetaData {
             }
         }
     }
+
+    @Test(groups = {"IT"})
+    public void testGetFunctions() throws Exception {
+        try (Connection connection = createConnection()) {
+            try (ResultSet rs = connection.getMetaData().getFunctions(null, null, "abs")) {
+                ResultSetMetaData metadata = rs.getMetaData();
+                assertEquals(metadata.getColumnCount(), 6);
+
+                assertEquals(metadata.getColumnLabel(1).toUpperCase(Locale.US), "FUNCTION_CAT");
+                assertEquals(metadata.getColumnType(1), Types.VARCHAR);
+
+                assertEquals(metadata.getColumnLabel(2).toUpperCase(Locale.US), "FUNCTION_SCHEMA");
+                assertEquals(metadata.getColumnType(2), Types.VARCHAR);
+
+                assertEquals(metadata.getColumnLabel(3).toUpperCase(Locale.US), "FUNCTION_NAME");
+                assertEquals(metadata.getColumnType(3), Types.VARCHAR);
+
+                assertEquals(metadata.getColumnLabel(4).toUpperCase(Locale.US), "REMARKS");
+                assertEquals(metadata.getColumnType(4), Types.VARCHAR);
+
+                assertEquals(metadata.getColumnLabel(5).toUpperCase(Locale.US), "FUNCTION_TYPE");
+                assertEquals(metadata.getColumnType(5), Types.TINYINT);
+
+                assertEquals(metadata.getColumnLabel(6).toUpperCase(Locale.US), "SPECIFIC_NAME");
+                assertEquals(metadata.getColumnType(6), Types.VARCHAR);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Just match RegEx in Full string "Databend Query vx.y.zzz" or "DatabendQuery vx.y.zzz"
Fixes https://github.com/datafuselabs/databend-jdbc/issues/204