### PR TITLE
Fix shaded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,12 +153,12 @@
                                     <shadedPattern>com.databend.jdbc.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.slf4j.slf4j-api</pattern>
-                                    <shadedPattern>com.databend.jdbc.slf4j-api</shadedPattern>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>com.databend.jdbc.org.slf4j</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.apache.commons.commons-lang3</pattern>
-                                    <shadedPattern>com.databend.jdbc.commons-lang3</shadedPattern>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>com.databend.jdbc.org.apache.commons.lang3</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Relocation's pattern property supports packages. However, current syntax
declares groupId.artifactId, which doesn't relocate some packages.

This is causing issues when trying to use another version of commons-lang3.

Currently:

<img width="426" height="457" alt="Screenshot 2025-07-28 at 1 48 16 p m" src="https://github.com/user-attachments/assets/01a5760c-889d-4695-9cee-9ac5ebedd839" />

<img width="429" height="386" alt="Screenshot 2025-07-28 at 1 48 36 p m" src="https://github.com/user-attachments/assets/ed2e1332-42e5-46a6-8cd2-064eb1eb09a7" />
