### PR TITLE
fix: Avoid Optional in fields/params - intended solely for return types

### DIFF
--- a/databend-client/src/main/java/com/databend/client/DatabendClientV1.java
+++ b/databend-client/src/main/java/com/databend/client/DatabendClientV1.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -57,7 +56,7 @@ public class DatabendClientV1
 
     public static final String QUERY_PATH = "/v1/query";
     public static final String DISCOVERY_PATH = "/v1/discovery_nodes";
-    private static final long MAX_MATERIALIZED_JSON_RESPONSE_SIZE = 128 * 1024;
+    private static final Long MAX_MATERIALIZED_JSON_RESPONSE_SIZE = 128 * 1024L;
     private final OkHttpClient httpClient;
     private final String query;
     private final String host;
@@ -109,7 +108,7 @@ public class DatabendClientV1
         requireNonNull(settings, "settings is null");
         requireNonNull(settings.getHost(), "settings.host is null");
         Request request = buildDiscoveryRequest(settings);
-        DiscoveryResponseCodec.DiscoveryResponse response = getDiscoveryResponse(httpClient, request, OptionalLong.empty(), settings.getQueryTimeoutSecs());
+        DiscoveryResponseCodec.DiscoveryResponse response = getDiscoveryResponse(httpClient, request, null, settings.getQueryTimeoutSecs());
         return response.getNodes();
     }
 
@@ -169,7 +168,7 @@ public class DatabendClientV1
         return query;
     }
 
-    private static DiscoveryResponseCodec.DiscoveryResponse getDiscoveryResponse(OkHttpClient httpClient, Request request, OptionalLong materializedJsonSizeLimit, int requestTimeoutSecs) {
+    private static DiscoveryResponseCodec.DiscoveryResponse getDiscoveryResponse(OkHttpClient httpClient, Request request, Long materializedJsonSizeLimit, int requestTimeoutSecs) {
         requireNonNull(request, "request is null");
 
         long start = System.nanoTime();
@@ -237,7 +236,7 @@ public class DatabendClientV1
         }
     }
 
-    private boolean executeInternal(Request request, OptionalLong materializedJsonSizeLimit) {
+    private boolean executeInternal(Request request, Long materializedJsonSizeLimit) {
         requireNonNull(request, "request is null");
 
         long start = System.nanoTime();
@@ -328,7 +327,7 @@ public class DatabendClientV1
 
     @Override
     public boolean execute(Request request) {
-        return executeInternal(request, OptionalLong.empty());
+        return executeInternal(request, null);
     }
 
     private void processResponse(Headers headers, QueryResults results) {
@@ -378,7 +377,7 @@ public class DatabendClientV1
         Request.Builder builder = prepareRequest(url, this.additonalHeaders);
         builder.addHeader(ClientSettings.X_DATABEND_STICKY_NODE, this.nodeID);
         Request request = builder.get().build();
-        return executeInternal(request, OptionalLong.of(MAX_MATERIALIZED_JSON_RESPONSE_SIZE));
+        return executeInternal(request, MAX_MATERIALIZED_JSON_RESPONSE_SIZE);
     }
 
     @Override

--- a/databend-client/src/main/java/com/databend/client/JsonResponse.java
+++ b/databend-client/src/main/java/com/databend/client/JsonResponse.java
@@ -20,8 +20,8 @@ import okhttp3.*;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.net.HttpHeaders.LOCATION;
@@ -59,7 +59,7 @@ public final class JsonResponse<T> {
         this.hasValue = (exception == null);
     }
 
-    public static <T> JsonResponse<T> execute(JsonCodec<T> codec, OkHttpClient client, Request request, OptionalLong materializedJsonSizeLimit) throws RuntimeException {
+    public static <T> JsonResponse<T> execute(JsonCodec<T> codec, OkHttpClient client, Request request, Long materializedJsonSizeLimit) throws RuntimeException {
         try (Response response = client.newCall(request).execute()) {
             // TODO: fix in OkHttp: https://github.com/square/okhttp/issues/3111
             if ((response.code() == 307) || (response.code() == 308)) {
@@ -76,7 +76,7 @@ public final class JsonResponse<T> {
                 T value = null;
                 IllegalArgumentException exception = null;
                 try {
-                    if (materializedJsonSizeLimit.isPresent() && (responseBody.contentLength() < 0 || responseBody.contentLength() > materializedJsonSizeLimit.getAsLong())) {
+                    if (!Objects.isNull(materializedJsonSizeLimit) && (responseBody.contentLength() < 0 || responseBody.contentLength() > materializedJsonSizeLimit)) {
                         // Parse from input stream, response is either of unknown size or too large to materialize. Raw response body
                         // will not be available if parsing fails
                         value = codec.fromJson(responseBody.byteStream());


### PR DESCRIPTION
fix: Avoid Optional in fields/params - intended solely for return types （from Qodana）