### PR TITLE
fix:  fix and unify retry logic

### DIFF
--- a/databend-client/src/main/java/com/databend/client/RetryPolicy.java
+++ b/databend-client/src/main/java/com/databend/client/RetryPolicy.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.databend.client;
+
+import com.databend.client.errors.CloudErrors;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.sql.SQLException;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+
+public class RetryPolicy {
+    private static final Logger logger = Logger.getLogger(RetryPolicy.class.getPackage().getName());
+
+    public static class ResponseWithBody {
+        public Response response;
+        public String body;
+
+        public ResponseWithBody(Response response, String body) {
+            this.response = response;
+            this.body = body;
+        }
+    }
+    private final boolean ignore404;
+    private final boolean retry503;
+
+    private static final Random RANDOM = new Random();
+    private static final int MAX_ATTEMPTS = 3;
+    private static final long INITIAL_INTERVAL = 1000; // 1s
+    private static final double MULTIPLIER = 4.0;
+    private static final long MAX_INTERVAL = 30000; // 20s
+    public RetryPolicy(boolean ignore404, boolean retry503) {
+        this.ignore404 = ignore404;
+        this.retry503 = retry503;
+    }
+
+    public boolean shouldIgnore(int code) {
+        return ignore404 && code == 404;
+    }
+
+    public boolean shouldRetry(int code, String body) {
+        if (retry503 && (code == 502 || code == 503))
+            return  true;
+
+        CloudErrors errors = CloudErrors.tryParse(body);
+        if (errors != null) {
+            return errors.tryGetErrorKind().canRetry();
+        }
+        return false;
+    }
+
+    public boolean shouldRetry(IOException e) {
+        return  e.getCause() instanceof ConnectException;
+    }
+
+    private static long calculateBackoffInterval(int attempts) {
+        long baseInterval = (long) (INITIAL_INTERVAL * Math.pow(MULTIPLIER, attempts - 2));
+        baseInterval = Math.min(baseInterval, MAX_INTERVAL);
+        double jitter = 1.0 - RANDOM.nextDouble() * 0.3;
+        return (long) (baseInterval * jitter);
+    }
+
+    public RetryPolicy.ResponseWithBody sendRequestWithRetry(OkHttpClient httpClient, Request request) throws SQLException {
+        String failReason = null;
+        Throwable cause = null;
+
+        int attempts = 1;
+        long start = System.currentTimeMillis();
+        for (; attempts <= MAX_ATTEMPTS; attempts++) {
+            if (attempts > 1) {
+                try {
+                    long interval = calculateBackoffInterval(attempts);
+                    logger.log(Level.INFO, "Execute attempt #" + attempts + ", after " + interval + "ms");
+                    MILLISECONDS.sleep(interval);
+                } catch (InterruptedException e2) {
+                    Thread.currentThread().interrupt();
+                    throw new SQLException("Thread Interrupted");
+                }
+            }
+            try (Response response = httpClient.newCall(request).execute()) {
+                int code = response.code();
+                if (code != 200) {
+                    if (this.shouldIgnore(code)) {
+                        return new RetryPolicy.ResponseWithBody(response, "");
+                    } else {
+                        String body = response.body().string();
+                        if (!this.shouldRetry(code, body)) {
+                            failReason = String.format("status_code = %s, body = %s", code, body);
+                            break;
+                        }
+                    }
+                } else {
+                    String body = response.body().string();
+                    return new RetryPolicy.ResponseWithBody(response, body);
+                }
+            } catch (IOException e) {
+                failReason = e.getMessage();
+                cause = e.getCause();
+                if (!this.shouldRetry(e) || attempts == MAX_ATTEMPTS) {
+                    break;
+                }
+            }
+        }
+        long t = System.currentTimeMillis() - start;
+        String msg = String.format("Error accessing %s: %s after %s attempts (totally %s msecs)", request.url(), failReason, attempts, t);
+        throw new SQLException(msg, cause);
+    }
+}

--- a/databend-client/src/test/java/com/databend/client/TestClientIT.java
+++ b/databend-client/src/test/java/com/databend/client/TestClientIT.java
@@ -66,7 +66,7 @@ public class TestClientIT {
             Assert.fail("Expected exception was not thrown");
         } catch (Exception e) {
             Assert.assertTrue(
-                    e instanceof ConnectException || e.getCause() instanceof ConnectException, "Exception should be ConnectionException or contain ConnectionException as cause");
+                    e.getCause().getCause() instanceof ConnectException, "Exception should be ConnectionException or contain ConnectionException as cause");
 
         }
     }
@@ -122,6 +122,7 @@ public class TestClientIT {
             DatabendClientV1.discoverNodes(client, settings);
             Assert.fail("Expected exception was not thrown");
         } catch (Exception e) {
+            System.out.println(e);
             Assert.assertTrue(e instanceof UnsupportedOperationException, "Exception should be UnsupportedOperationException");
         }
     }

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendStatement.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendStatement.java
@@ -220,7 +220,7 @@ public class DatabendStatement implements Statement {
             return true;
         } catch (RuntimeException e) {
             throw new SQLException(
-                    "Error executing query: " + "SQL: " + sql + " " + e.getMessage() + " cause: " + e.getCause(), e);
+                    "Error executing query: " + "SQL: " + sql + ", error = " + e.getMessage() + ", cause: " + e.getCause(), e);
         } finally {
             executingClient.set(null);
             if (currentResult.get() == null) {

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestBasicDriver.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestBasicDriver.java
@@ -55,6 +55,31 @@ public class TestBasicDriver {
         }
     }
 
+//    @Test(groups = {"IT"})
+//    public void testRetry()
+//            throws SQLException {
+//        try (Connection connection = Utils.createConnection();
+//             Statement statement = connection.createStatement()) {
+//            statement.execute("select * from numbers(1000000)");
+//            ResultSet r = statement.getResultSet();
+//            for (int b = 1; b < 100; b++) {
+//                for (int i = 1; i < 10000; i++) {
+//                    if (r.next()) {
+//                        r.getInt(1);
+//                    } else {
+//                        System.out.println("stop");
+//                        return;
+//                    }
+//                }
+//                System.out.println("sleep");
+//                // restart nginx manually
+//                Thread.sleep(1000);
+//            }
+//        } catch (InterruptedException e) {
+//            throw new RuntimeException(e);
+//        }
+//    }
+
     @Test(groups = {"IT"})
     public void testExecuteInvalidSql() {
         assertThrows(SQLException.class, () -> {

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestTransaction.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestTransaction.java
@@ -114,6 +114,7 @@ public class TestTransaction {
             // Bug: Transaction timeout: last_query_id 9b619dc70fd64d6b8de7490aaf486f5c not found on this server
             if (!Compatibility.skipBugLowerThenOrEqualTo("1.2.790", "0.3.9")) {
                 // e.g. Unresolvable conflict detected for table 2249
+                System.out.println(exception);
                 Assert.assertTrue(exception.getMessage().toLowerCase().contains("conflict"), exception.getMessage());
             }
 


### PR DESCRIPTION

1. move RetryPolicy to databend-client for reuse.
1. skip fail over if only one nodes (most of the case)