### PR TITLE
refactore:  refines retry and error propagation

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/HttpRetryPolicy.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/HttpRetryPolicy.java
@@ -67,7 +67,7 @@ public class HttpRetryPolicy {
     }
 
     public static boolean isRetryableHttpStatus(int code) {
-        return code == 502 || code == 503 || code == 504;
+        return code == 502 || code == 503;
     }
 
     public boolean shouldRetry(int code, String body) {

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/HttpRetryPolicy.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/HttpRetryPolicy.java
@@ -66,8 +66,12 @@ public class HttpRetryPolicy {
         return ignore404 && code == 404;
     }
 
+    public static boolean isRetryableHttpStatus(int code) {
+        return code == 502 || code == 503 || code == 504;
+    }
+
     public boolean shouldRetry(int code, String body) {
-        if (retry503 && (code == 502 || code == 503)) {
+        if (retry503 && isRetryableHttpStatus(code)) {
             return true;
         }
         CloudErrors errors = CloudErrors.tryParse(body);

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/NonRetryableHttpStatusException.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/NonRetryableHttpStatusException.java
@@ -1,0 +1,9 @@
+package com.databend.jdbc.internal.http;
+
+import java.io.IOException;
+
+public final class NonRetryableHttpStatusException extends IOException {
+    public NonRetryableHttpStatusException(String message) {
+        super(message);
+    }
+}

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignClient.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignClient.java
@@ -15,6 +15,7 @@ import okio.Source;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
@@ -82,7 +83,7 @@ public class PresignClient {
                             formatFailureMessage("Unauthorized user: " + response.code() + " " + response.message())
                                     + formatErrorBody(responseBody));
                 }
-                else if (HttpRetryPolicy.isRetryableHttpStatus(response.code())) {
+                else if (isRetryablePresignStatus(response.code())) {
                     throw new RetryableHttpStatusException(formatFailureMessage(
                             "service unavailable: " + response.code() + " " + response.message()));
                 }
@@ -109,14 +110,18 @@ public class PresignClient {
                 Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
                 if (sinceStart.getSeconds() >= 900 || attempts >= MaxRetryAttempts) {
                     logger.warning(formatFailureMessage("error is: " + e));
-                    throw new RuntimeException(format("%s (attempts: %s, duration: %s)", PRESIGN_REQUEST_FAILED, attempts, sinceStart), e);
+                    throw new PresignRequestFailedException(
+                            format("%s (attempts: %s, duration: %s)", PRESIGN_REQUEST_FAILED, attempts, sinceStart),
+                            e);
                 }
                 try {
                     MILLISECONDS.sleep(attempts * 100);
                 }
                 catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();
-                    throw new RuntimeException("PresignClient thread was interrupted");
+                    InterruptedIOException exception = new InterruptedIOException("PresignClient thread was interrupted");
+                    exception.initCause(interruptedException);
+                    throw exception;
                 }
             }
             finally {
@@ -146,6 +151,10 @@ public class PresignClient {
                 ? cause.getMessage()
                 : formatFailureMessage("retry aborted because request body is not replayable");
         return new IOException(message, cause);
+    }
+
+    static boolean isRetryablePresignStatus(int code) {
+        return HttpRetryPolicy.isRetryableHttpStatus(code) || code == 504;
     }
 
     private static String readErrorBody(Response response) throws IOException {

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignClient.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignClient.java
@@ -29,12 +29,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class PresignClient {
     private static final String PRESIGN_REQUEST_FAILED = "Presign request failed";
 
-    private static final class NonRetryablePresignFailure extends RuntimeException {
-        private NonRetryablePresignFailure(String message) {
-            super(message);
-        }
-    }
-
     private static final int MaxRetryAttempts = 20;
     private static final int MAX_ERROR_BODY_LENGTH = 1024;
     private final OkHttpClient client;
@@ -74,32 +68,7 @@ public class PresignClient {
         requireNonNull(request, "request is null");
         long start = System.nanoTime();
         long attempts = 0;
-        Exception cause = null;
         while (true) {
-            if (attempts > 0 && request.body() != null && request.body().isOneShot()) {
-                logger.warning(formatFailureMessage("retry aborted because request body is not replayable"));
-                throw retryAbortedIOException(cause);
-            }
-            if (attempts > 0) {
-                logger.info(format("%s #%s due to: %s", "retry presign request", attempts, cause));
-                Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
-                if (sinceStart.getSeconds() >= 900) {
-                    logger.warning(formatFailureMessage("error is: " + cause));
-                    throw new RuntimeException(format("%s (attempts: %s, duration: %s)", PRESIGN_REQUEST_FAILED, attempts, sinceStart), cause);
-                }
-                if (attempts >= MaxRetryAttempts) {
-                    logger.warning(formatFailureMessage("error is: " + cause));
-                    throw new RuntimeException(format("%s (attempts: %s, duration: %s)", PRESIGN_REQUEST_FAILED, attempts, sinceStart), cause);
-                }
-
-                try {
-                    MILLISECONDS.sleep(attempts * 100);
-                }
-                catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException("PresignClient thread was interrupted");
-                }
-            }
             attempts++;
             Response response = null;
             try {
@@ -109,17 +78,22 @@ public class PresignClient {
                 }
                 String responseBody = readErrorBody(response);
                 if (response.code() == 401) {
-                    throw new NonRetryablePresignFailure(
+                    throw new NonRetryableHttpStatusException(
                             formatFailureMessage("Unauthorized user: " + response.code() + " " + response.message())
                                     + formatErrorBody(responseBody));
                 }
-                else if (response.code() >= 503) {
+                else if (HttpRetryPolicy.isRetryableHttpStatus(response.code())) {
                     throw new RetryableHttpStatusException(formatFailureMessage(
                             "service unavailable: " + response.code() + " " + response.message()));
                 }
                 else if (response.code() >= 400) {
-                    throw new NonRetryablePresignFailure(
+                    throw new NonRetryableHttpStatusException(
                             formatFailureMessage("configuration error: " + response.code() + " " + response.message())
+                                    + formatErrorBody(responseBody));
+                }
+                else {
+                    throw new NonRetryableHttpStatusException(
+                            formatFailureMessage("unexpected response: " + response.code() + " " + response.message())
                                     + formatErrorBody(responseBody));
                 }
             }
@@ -127,10 +101,23 @@ public class PresignClient {
                 if (!HttpRetryPolicy.isRetryableIOException(e)) {
                     throw e;
                 }
-                cause = e;
-            }
-            catch (NonRetryablePresignFailure e) {
-                throw e;
+                if (request.body() != null && request.body().isOneShot()) {
+                    logger.warning(formatFailureMessage("retry aborted because request body is not replayable"));
+                    throw retryAbortedIOException(e);
+                }
+                logger.info(format("%s #%s due to: %s", "retry presign request", attempts, e));
+                Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
+                if (sinceStart.getSeconds() >= 900 || attempts >= MaxRetryAttempts) {
+                    logger.warning(formatFailureMessage("error is: " + e));
+                    throw new RuntimeException(format("%s (attempts: %s, duration: %s)", PRESIGN_REQUEST_FAILED, attempts, sinceStart), e);
+                }
+                try {
+                    MILLISECONDS.sleep(attempts * 100);
+                }
+                catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("PresignClient thread was interrupted");
+                }
             }
             finally {
                 if (shouldClose) {
@@ -193,28 +180,21 @@ public class PresignClient {
     }
 
     public void presignDownload(String destFileName, Headers headers, String presignedUrl)
+            throws IOException
     {
         Request r = getRequest(headers, presignedUrl);
-        try (ResponseBody body = executeInternal(r, false)) {
-            BufferedSink sink = Okio.buffer(Okio.sink(new File(destFileName)));
+        try (ResponseBody body = executeInternal(r, false);
+                BufferedSink sink = Okio.buffer(Okio.sink(new File(destFileName)))) {
             sink.writeAll(body.source());
-            sink.close();
-        }
-        catch (IOException e) {
-            throw new RuntimeException("presignDownload failed", e);
         }
     }
 
     public InputStream presignDownloadStream(Headers headers, String presignedUrl)
+            throws IOException
     {
         Request r = getRequest(headers, presignedUrl);
-        try {
-            ResponseBody responseBody = executeInternal(r, false);
-            return responseBody.byteStream();
-        }
-        catch (IOException e) {
-            throw new RuntimeException("presignDownloadStream failed", e);
-        }
+        ResponseBody responseBody = executeInternal(r, false);
+        return responseBody.byteStream();
     }
 
     private Request getRequest(Headers headers, String url)

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignRequestFailedException.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignRequestFailedException.java
@@ -1,0 +1,9 @@
+package com.databend.jdbc.internal.http;
+
+import java.io.IOException;
+
+public final class PresignRequestFailedException extends IOException {
+    public PresignRequestFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/session/DatabendSessionHandle.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/session/DatabendSessionHandle.java
@@ -6,6 +6,7 @@ import com.databend.jdbc.internal.exception.DatabendQueryException;
 import com.databend.jdbc.internal.exception.DatabendSessionException;
 import com.databend.jdbc.internal.exception.DatabendStageUploadException;
 import com.databend.jdbc.internal.exception.DatabendStreamingLoadException;
+import com.databend.jdbc.internal.http.NonRetryableHttpStatusException;
 import com.databend.jdbc.internal.http.PresignClient;
 import com.databend.jdbc.internal.http.HttpRetryPolicy;
 import com.databend.jdbc.internal.http.JsonCodec;
@@ -367,7 +368,7 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
         }
         try {
             return client.presignDownloadStream(presigned.headers, presigned.url);
-        } catch (RuntimeException e) {
+        } catch (IOException e) {
             throw new SQLException(
                     "Failed to open presigned download stream",
                     new DatabendPresignException("Failed to open presigned download stream", e));
@@ -532,30 +533,7 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
 
         long start = System.nanoTime();
         long attempts = 0;
-        Exception cause = null;
         while (true) {
-            if (attempts > 0 && request.body() != null && request.body().isOneShot()) {
-                logger.warning("Upload to stage retry aborted because request body is not replayable");
-                throw replayAbortedStageUploadException(cause);
-            }
-            if (attempts > 0) {
-                logger.info("try to upload to stage again: " + attempts + ", cause: " + cause);
-                Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
-                if (sinceStart.compareTo(STAGE_UPLOAD_RETRY_TIMEOUT) >= 0 || attempts >= MAX_STAGE_UPLOAD_RETRY_ATTEMPTS) {
-                    logger.warning("Upload to stage failed, error is: " + cause);
-                    throw new DatabendStageUploadException(
-                            String.format("Error upload to stage (attempts: %s, duration: %s)", attempts, sinceStart),
-                            cause);
-                }
-
-                try {
-                    MILLISECONDS.sleep(attempts * 100);
-                }
-                catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException("StatementClient thread was interrupted");
-                }
-            }
             attempts++;
 
             Response response = null;
@@ -565,26 +543,46 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
                     return;
                 }
                 if (response.code() == 401) {
-                    throw new NonRetryableStageUploadFailure("Error upload to stage, Unauthorized user: "
+                    throw new NonRetryableHttpStatusException("Error upload to stage, Unauthorized user: "
                             + response.code() + " " + response.message());
                 }
-                if (response.code() >= 503) {
+                if (HttpRetryPolicy.isRetryableHttpStatus(response.code())) {
                     throw new RetryableHttpStatusException("Error upload to stage, service unavailable: "
                             + response.code() + " " + response.message());
                 }
                 else if (response.code() >= 400) {
-                    throw new NonRetryableStageUploadFailure("Error upload to stage, configuration error: "
+                    throw new NonRetryableHttpStatusException("Error upload to stage, configuration error: "
+                            + response.code() + " " + response.message());
+                }
+                else {
+                    throw new NonRetryableHttpStatusException("Error upload to stage, unexpected response: "
                             + response.code() + " " + response.message());
                 }
             }
             catch (IOException e) {
                 if (!HttpRetryPolicy.isRetryableIOException(e)) {
-                    throw e;
+                    throw new DatabendStageUploadException(e.getMessage(), e);
                 }
-                cause = e;
-            }
-            catch (NonRetryableStageUploadFailure e) {
-                throw new DatabendStageUploadException(e.getMessage(), e);
+                if (request.body() != null && request.body().isOneShot()) {
+                    logger.warning("Upload to stage retry aborted because request body is not replayable");
+                    throw retryAbortedStageUploadException(e);
+                }
+                logger.info("try to upload to stage again: " + attempts + ", cause: " + e);
+                Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
+                if (sinceStart.compareTo(STAGE_UPLOAD_RETRY_TIMEOUT) >= 0 || attempts >= MAX_STAGE_UPLOAD_RETRY_ATTEMPTS) {
+                    logger.warning("Upload to stage failed, error is: " + e);
+                    throw new DatabendStageUploadException(
+                            String.format("Error upload to stage (attempts: %s, duration: %s)", attempts, sinceStart),
+                            e);
+                }
+
+                try {
+                    MILLISECONDS.sleep(attempts * 100);
+                }
+                catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("StatementClient thread was interrupted");
+                }
             }
             finally {
                 if (response != null) {
@@ -798,13 +796,7 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
         }
     }
 
-    private static final class NonRetryableStageUploadFailure extends RuntimeException {
-        private NonRetryableStageUploadFailure(String message) {
-            super(message);
-        }
-    }
-
-    private static DatabendStageUploadException replayAbortedStageUploadException(Exception cause) {
+    private static DatabendStageUploadException retryAbortedStageUploadException(IOException cause) {
         String message = cause != null && cause.getMessage() != null
                 ? cause.getMessage()
                 : "Upload to stage retry aborted because request body is not replayable";

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestHttpRetryPolicy.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestHttpRetryPolicy.java
@@ -150,14 +150,69 @@ public class TestHttpRetryPolicy {
     }
 
     @Test(groups = {"UNIT"})
+    public void testRetryable504EventuallySucceeds() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/gateway-timeout", exchange -> {
+            try {
+                int attempt = attempts.incrementAndGet();
+                if (attempt < 3) {
+                    byte[] payload = "{\"error\":\"temporary\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(504, payload.length);
+                    exchange.getResponseBody().write(payload);
+                    return;
+                }
+                byte[] payload = "{\"ok\":true}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, payload.length);
+                exchange.getResponseBody().write(payload);
+            }
+            finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        try {
+            HttpRetryPolicy retryPolicy = new HttpRetryPolicy(false, true);
+            HttpRetryPolicy.ResponseWithBody response = retryPolicy.sendRequestWithRetry(
+                    new OkHttpClient(),
+                    new Request.Builder().url(serverUrl(server, "/gateway-timeout")).get().build());
+
+            Assert.assertEquals(response.statusCode, 200);
+            Assert.assertEquals(response.bodyString(), "{\"ok\":true}");
+            Assert.assertEquals(attempts.get(), 3);
+        }
+        finally {
+            server.stop(0);
+        }
+    }
+
+    @Test(groups = {"UNIT"})
     public void testSocketTimeoutExceptionIsRetryable() {
         Assert.assertTrue(HttpRetryPolicy.isRetryableIOException(new SocketTimeoutException("timed out")));
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testRetryableHttpStatusCodes() {
+        Assert.assertTrue(HttpRetryPolicy.isRetryableHttpStatus(502));
+        Assert.assertTrue(HttpRetryPolicy.isRetryableHttpStatus(503));
+        Assert.assertTrue(HttpRetryPolicy.isRetryableHttpStatus(504));
+        Assert.assertFalse(HttpRetryPolicy.isRetryableHttpStatus(500));
+        Assert.assertFalse(HttpRetryPolicy.isRetryableHttpStatus(505));
     }
 
     @Test(groups = {"UNIT"})
     public void testRetryableHttpStatusExceptionIsRetryable() {
         Assert.assertTrue(HttpRetryPolicy.isRetryableIOException(
                 new RetryableHttpStatusException("service unavailable: 503 Service Unavailable")));
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testNonRetryableHttpStatusExceptionIsNotRetryable() {
+        Assert.assertFalse(HttpRetryPolicy.isRetryableIOException(
+                new NonRetryableHttpStatusException("configuration error: 400 Bad Request")));
     }
 
     private static String serverUrl(HttpServer server, String path) {

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestHttpRetryPolicy.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestHttpRetryPolicy.java
@@ -150,22 +150,15 @@ public class TestHttpRetryPolicy {
     }
 
     @Test(groups = {"UNIT"})
-    public void testRetryable504EventuallySucceeds() throws Exception {
+    public void testGatewayTimeoutIsNotRetriedByGenericPolicy() throws Exception {
         AtomicInteger attempts = new AtomicInteger();
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/gateway-timeout", exchange -> {
             try {
-                int attempt = attempts.incrementAndGet();
-                if (attempt < 3) {
-                    byte[] payload = "{\"error\":\"temporary\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                    exchange.getResponseHeaders().add("Content-Type", "application/json");
-                    exchange.sendResponseHeaders(504, payload.length);
-                    exchange.getResponseBody().write(payload);
-                    return;
-                }
-                byte[] payload = "{\"ok\":true}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+                attempts.incrementAndGet();
+                byte[] payload = "{\"error\":\"temporary\"}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
                 exchange.getResponseHeaders().add("Content-Type", "application/json");
-                exchange.sendResponseHeaders(200, payload.length);
+                exchange.sendResponseHeaders(504, payload.length);
                 exchange.getResponseBody().write(payload);
             }
             finally {
@@ -176,13 +169,12 @@ public class TestHttpRetryPolicy {
 
         try {
             HttpRetryPolicy retryPolicy = new HttpRetryPolicy(false, true);
-            HttpRetryPolicy.ResponseWithBody response = retryPolicy.sendRequestWithRetry(
+            SQLException exception = Assert.expectThrows(SQLException.class, () -> retryPolicy.sendRequestWithRetry(
                     new OkHttpClient(),
-                    new Request.Builder().url(serverUrl(server, "/gateway-timeout")).get().build());
+                    new Request.Builder().url(serverUrl(server, "/gateway-timeout")).get().build()));
 
-            Assert.assertEquals(response.statusCode, 200);
-            Assert.assertEquals(response.bodyString(), "{\"ok\":true}");
-            Assert.assertEquals(attempts.get(), 3);
+            Assert.assertTrue(exception.getMessage().contains("status_code = 504"), exception.getMessage());
+            Assert.assertEquals(attempts.get(), 1);
         }
         finally {
             server.stop(0);
@@ -198,7 +190,7 @@ public class TestHttpRetryPolicy {
     public void testRetryableHttpStatusCodes() {
         Assert.assertTrue(HttpRetryPolicy.isRetryableHttpStatus(502));
         Assert.assertTrue(HttpRetryPolicy.isRetryableHttpStatus(503));
-        Assert.assertTrue(HttpRetryPolicy.isRetryableHttpStatus(504));
+        Assert.assertFalse(HttpRetryPolicy.isRetryableHttpStatus(504));
         Assert.assertFalse(HttpRetryPolicy.isRetryableHttpStatus(500));
         Assert.assertFalse(HttpRetryPolicy.isRetryableHttpStatus(505));
     }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestPresignClient.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestPresignClient.java
@@ -103,6 +103,41 @@ public class TestPresignClient {
     }
 
     @Test(groups = {"UNIT"})
+    public void testPresignDownloadRetriesGatewayTimeout() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/download-504", exchange -> {
+            try {
+                int attempt = attempts.incrementAndGet();
+                if (attempt < 3) {
+                    exchange.sendResponseHeaders(504, -1);
+                    return;
+                }
+                byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, payload.length);
+                exchange.getResponseBody().write(payload);
+            }
+            finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        Path file = Files.createTempFile("databend-presign-504-", ".txt");
+        try {
+            PresignClient client = new PresignClient();
+            client.presignDownload(file.toString(), emptyHeaders(), serverUrl(server, "/download-504"));
+
+            Assert.assertEquals(new String(Files.readAllBytes(file), StandardCharsets.UTF_8), "hello");
+            Assert.assertEquals(attempts.get(), 3);
+        }
+        finally {
+            Files.deleteIfExists(file);
+            server.stop(0);
+        }
+    }
+
+    @Test(groups = {"UNIT"})
     public void testPresignDownloadStreamPropagatesUnauthorizedFailure() throws Exception {
         AtomicInteger attempts = new AtomicInteger();
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
@@ -270,6 +305,14 @@ public class TestPresignClient {
         finally {
             server.stop(0);
         }
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testRetryablePresignStatusCodes() {
+        Assert.assertTrue(PresignClient.isRetryablePresignStatus(502));
+        Assert.assertTrue(PresignClient.isRetryablePresignStatus(503));
+        Assert.assertTrue(PresignClient.isRetryablePresignStatus(504));
+        Assert.assertFalse(PresignClient.isRetryablePresignStatus(500));
     }
 
     private static Headers emptyHeaders() {

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestPresignClient.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestPresignClient.java
@@ -68,7 +68,42 @@ public class TestPresignClient {
     }
 
     @Test(groups = {"UNIT"})
-    public void testPresignDownloadStreamWrapsUnauthorizedFailure() throws Exception {
+    public void testPresignDownloadRetriesBadGateway() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/download-502", exchange -> {
+            try {
+                int attempt = attempts.incrementAndGet();
+                if (attempt < 3) {
+                    exchange.sendResponseHeaders(502, -1);
+                    return;
+                }
+                byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, payload.length);
+                exchange.getResponseBody().write(payload);
+            }
+            finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        Path file = Files.createTempFile("databend-presign-502-", ".txt");
+        try {
+            PresignClient client = new PresignClient();
+            client.presignDownload(file.toString(), emptyHeaders(), serverUrl(server, "/download-502"));
+
+            Assert.assertEquals(new String(Files.readAllBytes(file), StandardCharsets.UTF_8), "hello");
+            Assert.assertEquals(attempts.get(), 3);
+        }
+        finally {
+            Files.deleteIfExists(file);
+            server.stop(0);
+        }
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testPresignDownloadStreamPropagatesUnauthorizedFailure() throws Exception {
         AtomicInteger attempts = new AtomicInteger();
         HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/download-stream", exchange -> {
@@ -85,11 +120,45 @@ public class TestPresignClient {
         try {
             PresignClient client = new PresignClient();
 
-            RuntimeException exception = Assert.expectThrows(RuntimeException.class, () ->
+            IOException exception = Assert.expectThrows(IOException.class, () ->
                     client.presignDownloadStream(emptyHeaders(), serverUrl(server, "/download-stream")));
 
+            Assert.assertTrue(exception instanceof NonRetryableHttpStatusException, exception.getClass().getName());
             Assert.assertTrue(exception.getMessage().contains("Presign request failed"), exception.getMessage());
             Assert.assertTrue(exception.getMessage().contains("Unauthorized user"), exception.getMessage());
+            Assert.assertEquals(attempts.get(), 1);
+        }
+        finally {
+            server.stop(0);
+        }
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testPresignDownloadFailsFastOnUnexpectedRedirectStatus() throws Exception {
+        AtomicInteger attempts = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/download-300", exchange -> {
+            try {
+                attempts.incrementAndGet();
+                byte[] payload = "multiple choices".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(300, payload.length);
+                exchange.getResponseBody().write(payload);
+            }
+            finally {
+                exchange.close();
+            }
+        });
+        server.start();
+
+        try {
+            PresignClient client = new PresignClient();
+
+            IOException exception = Assert.expectThrows(IOException.class, () ->
+                    client.presignDownloadStream(emptyHeaders(), serverUrl(server, "/download-300")));
+
+            Assert.assertTrue(exception instanceof NonRetryableHttpStatusException, exception.getClass().getName());
+            Assert.assertTrue(exception.getMessage().contains("unexpected response"), exception.getMessage());
+            Assert.assertTrue(exception.getMessage().contains("300"), exception.getMessage());
             Assert.assertEquals(attempts.get(), 1);
         }
         finally {
@@ -115,7 +184,7 @@ public class TestPresignClient {
         try {
             PresignClient client = new PresignClient();
 
-            RuntimeException exception = Assert.expectThrows(RuntimeException.class, () -> client.presignUpload(
+            IOException exception = Assert.expectThrows(IOException.class, () -> client.presignUpload(
                     null,
                     new java.io.ByteArrayInputStream("abc".getBytes(StandardCharsets.UTF_8)),
                     emptyHeaders(),
@@ -123,6 +192,7 @@ public class TestPresignClient {
                     3,
                     true));
 
+            Assert.assertTrue(exception instanceof NonRetryableHttpStatusException, exception.getClass().getName());
             Assert.assertTrue(exception.getMessage().contains("Presign request failed"), exception.getMessage());
             Assert.assertTrue(exception.getMessage().contains("Unauthorized user"), exception.getMessage());
             Assert.assertEquals(attempts.get(), 1);
@@ -150,7 +220,7 @@ public class TestPresignClient {
         try {
             PresignClient client = new PresignClient();
 
-            RuntimeException exception = Assert.expectThrows(RuntimeException.class, () -> client.presignUpload(
+            IOException exception = Assert.expectThrows(IOException.class, () -> client.presignUpload(
                     null,
                     new java.io.ByteArrayInputStream("abc".getBytes(StandardCharsets.UTF_8)),
                     emptyHeaders(),
@@ -158,6 +228,7 @@ public class TestPresignClient {
                     3,
                     true));
 
+            Assert.assertTrue(exception instanceof NonRetryableHttpStatusException, exception.getClass().getName());
             Assert.assertTrue(exception.getMessage().contains("configuration error"), exception.getMessage());
             Assert.assertEquals(attempts.get(), 1);
         }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/session/TestDatabendSessionHandle.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/session/TestDatabendSessionHandle.java
@@ -8,6 +8,7 @@ import com.databend.jdbc.internal.exception.DatabendSessionException;
 import com.databend.jdbc.internal.exception.DatabendStageUploadException;
 import com.databend.jdbc.internal.exception.DatabendStreamingLoadException;
 import com.databend.jdbc.internal.http.NonRetryableHttpStatusException;
+import com.databend.jdbc.internal.http.PresignRequestFailedException;
 import com.databend.jdbc.internal.query.QueryResultPages;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -33,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -1073,6 +1075,58 @@ public class TestDatabendSessionHandle {
                     String.valueOf(exception.getCause().getCause()));
             Assert.assertTrue(exception.getCause().getCause().getMessage().contains("Unauthorized user"),
                     exception.getCause().getCause().getMessage());
+        }
+        finally {
+            queryServer.stop(0);
+            downloadServer.stop(0);
+        }
+    }
+
+    @Test(groups = {"UNIT"}, timeOut = 30000)
+    public void testDownloadStreamPresignedRetryExhaustionRaisesSQLException() throws Exception {
+        HttpServer queryServer = HttpServer.create(new InetSocketAddress(0), 0);
+        HttpServer downloadServer = HttpServer.create(new InetSocketAddress(0), 0);
+        AtomicInteger attempts = new AtomicInteger();
+        downloadServer.createContext("/download", exchange -> {
+            try {
+                attempts.incrementAndGet();
+                byte[] payload = "temporary".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(504, payload.length);
+                exchange.getResponseBody().write(payload);
+            }
+            finally {
+                exchange.close();
+            }
+        });
+        queryServer.createContext("/v1/query", exchange -> {
+            try {
+                byte[] response = presignQueryResponse("{}",
+                        "http://127.0.0.1:" + downloadServer.getAddress().getPort() + "/download")
+                        .getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, response.length);
+                exchange.getResponseBody().write(response);
+            }
+            finally {
+                exchange.close();
+            }
+        });
+        downloadServer.start();
+        queryServer.start();
+
+        try {
+            DatabendSessionHandle handle = createSessionHandle(
+                    URI.create("http://127.0.0.1:" + queryServer.getAddress().getPort()));
+
+            SQLException exception = Assert.expectThrows(SQLException.class,
+                    () -> handle.downloadStream("~", "path/file.txt"));
+            Assert.assertTrue(exception.getMessage().contains("Failed to open presigned download stream"), exception.getMessage());
+            Assert.assertTrue(exception.getCause() instanceof DatabendPresignException, String.valueOf(exception.getCause()));
+            Assert.assertTrue(exception.getCause().getCause() instanceof PresignRequestFailedException,
+                    String.valueOf(exception.getCause().getCause()));
+            Assert.assertTrue(exception.getCause().getCause().getMessage().contains("Presign request failed"),
+                    exception.getCause().getCause().getMessage());
+            Assert.assertEquals(attempts.get(), 20);
         }
         finally {
             queryServer.stop(0);

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/session/TestDatabendSessionHandle.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/session/TestDatabendSessionHandle.java
@@ -7,6 +7,7 @@ import com.databend.jdbc.internal.exception.DatabendQueryException;
 import com.databend.jdbc.internal.exception.DatabendSessionException;
 import com.databend.jdbc.internal.exception.DatabendStageUploadException;
 import com.databend.jdbc.internal.exception.DatabendStreamingLoadException;
+import com.databend.jdbc.internal.http.NonRetryableHttpStatusException;
 import com.databend.jdbc.internal.query.QueryResultPages;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -1068,6 +1069,8 @@ public class TestDatabendSessionHandle {
             Assert.assertTrue(exception.getCause() instanceof DatabendPresignException, String.valueOf(exception.getCause()));
             Assert.assertTrue(exception.getCause().getMessage().contains("Failed to open presigned download stream"),
                     exception.getCause().getMessage());
+            Assert.assertTrue(exception.getCause().getCause() instanceof NonRetryableHttpStatusException,
+                    String.valueOf(exception.getCause().getCause()));
             Assert.assertTrue(exception.getCause().getCause().getMessage().contains("Unauthorized user"),
                     exception.getCause().getCause().getMessage());
         }


### PR DESCRIPTION

 This PR refines retry and error propagation for presigned file transfer and stage upload flows.

  It separates retryable and non-retryable HTTP failures more clearly, so callers can distinguish transient failures from configuration or authorization issues. In particular, 502/503 remain retryable in the shared HTTP retry policy, while presign download/upload flows additionally treat 504 as retryable. Non-retryable HTTP responses now surface through  dedicated exception types instead of being wrapped as generic runtime failures.

  For presign flows, download/upload now propagate IOException-based failures directly, preserve clearer root causes, and return a dedicated PresignRequestFailedException when retry  attempts are exhausted. For stage upload, the retry path was aligned with the same classification logic so non-retryable HTTP failures are wrapped consistently as DatabendStageUploadException.

  Tests were added and updated to cover:

  - generic HTTP retry behavior for 502/503/504
  - presign retry behavior for 502/503/504
  - fail-fast handling for 401, 400, and unexpected HTTP statuses
  - retry exhaustion for presign download
  - session-handle level exception wrapping for presign and stage upload path
