### PR TITLE
fix: reduce retry attempts and use exponential backoff for presign/stage upload

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/HttpRetryPolicy.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/HttpRetryPolicy.java
@@ -79,6 +79,9 @@ public class HttpRetryPolicy {
     }
 
     public static boolean isRetryableIOException(IOException e) {
+        if (e instanceof NonRetryableHttpStatusException) {
+            return false;
+        }
         if (e instanceof RetryableHttpStatusException) {
             return true;
         }

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignClient.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/PresignClient.java
@@ -30,7 +30,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class PresignClient {
     private static final String PRESIGN_REQUEST_FAILED = "Presign request failed";
 
-    private static final int MaxRetryAttempts = 20;
+    private static final int MaxRetryAttempts = 5;
     private static final int MAX_ERROR_BODY_LENGTH = 1024;
     private final OkHttpClient client;
     private static final Logger logger = Logger.getLogger(PresignClient.class.getPackage().getName());
@@ -39,9 +39,9 @@ public class PresignClient {
     {
         Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINEST);
         this.client = new OkHttpClient.Builder()
-                .connectTimeout(600, TimeUnit.SECONDS)
-                .writeTimeout(900, TimeUnit.SECONDS)
-                .readTimeout(600, TimeUnit.SECONDS)
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(300, TimeUnit.SECONDS)
+                .readTimeout(300, TimeUnit.SECONDS)
                 .retryOnConnectionFailure(true)
                 .protocols(Arrays.asList(Protocol.HTTP_1_1))
                 .build();
@@ -107,15 +107,16 @@ public class PresignClient {
                     throw retryAbortedIOException(e);
                 }
                 logger.info(format("%s #%s due to: %s", "retry presign request", attempts, e));
-                Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
-                if (sinceStart.getSeconds() >= 900 || attempts >= MaxRetryAttempts) {
+                if (attempts > MaxRetryAttempts) {
+                    Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
                     logger.warning(formatFailureMessage("error is: " + e));
                     throw new PresignRequestFailedException(
                             format("%s (attempts: %s, duration: %s)", PRESIGN_REQUEST_FAILED, attempts, sinceStart),
                             e);
                 }
                 try {
-                    MILLISECONDS.sleep(attempts * 100);
+                    long sleepMs = Math.min(1000L * (1L << (attempts - 1)), 30_000L);
+                    MILLISECONDS.sleep(sleepMs);
                 }
                 catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/RetryableHttpFailure.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/RetryableHttpFailure.java
@@ -1,7 +1,0 @@
-package com.databend.jdbc.internal.http;
-
-public final class RetryableHttpFailure extends Exception {
-    public RetryableHttpFailure(String message) {
-        super(message);
-    }
-}

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/session/DatabendSessionHandle.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/session/DatabendSessionHandle.java
@@ -74,8 +74,7 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
     private static final Semver STREAMING_LOAD_MIN_VERSION = new Semver("1.2.781");
     private static final Semver HEARTBEAT_MIN_VERSION = new Semver("1.2.709");
     private static final int MIN_ARROW_RESULT_VERSION = 3;
-    private static final int MAX_STAGE_UPLOAD_RETRY_ATTEMPTS = 20;
-    private static final Duration STAGE_UPLOAD_RETRY_TIMEOUT = Duration.ofMinutes(5);
+    private static final int MAX_STAGE_UPLOAD_RETRY_ATTEMPTS = 5;
 
     private static volatile ExecutorService heartbeatScheduler = null;
 
@@ -524,9 +523,9 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
         requireNonNull(request, "request is null");
 
         OkHttpClient uploadClient = httpClient.newBuilder()
-                .connectTimeout(600, java.util.concurrent.TimeUnit.SECONDS)
-                .writeTimeout(900, java.util.concurrent.TimeUnit.SECONDS)
-                .readTimeout(600, java.util.concurrent.TimeUnit.SECONDS)
+                .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+                .writeTimeout(300, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(300, java.util.concurrent.TimeUnit.SECONDS)
                 .retryOnConnectionFailure(true)
                 .protocols(Arrays.asList(Protocol.HTTP_1_1))
                 .build();
@@ -568,8 +567,8 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
                     throw retryAbortedStageUploadException(e);
                 }
                 logger.info("try to upload to stage again: " + attempts + ", cause: " + e);
-                Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
-                if (sinceStart.compareTo(STAGE_UPLOAD_RETRY_TIMEOUT) >= 0 || attempts >= MAX_STAGE_UPLOAD_RETRY_ATTEMPTS) {
+                if (attempts >= MAX_STAGE_UPLOAD_RETRY_ATTEMPTS) {
+                    Duration sinceStart = Duration.ofNanos(System.nanoTime() - start);
                     logger.warning("Upload to stage failed, error is: " + e);
                     throw new DatabendStageUploadException(
                             String.format("Error upload to stage (attempts: %s, duration: %s)", attempts, sinceStart),
@@ -577,7 +576,8 @@ public class DatabendSessionHandle implements Consumer<SessionState> {
                 }
 
                 try {
-                    MILLISECONDS.sleep(attempts * 100);
+                    long sleepMs = Math.min(1000L * (1L << (attempts - 1)), 30_000L);
+                    MILLISECONDS.sleep(sleepMs);
                 }
                 catch (InterruptedException interruptedException) {
                     Thread.currentThread().interrupt();

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestHttpRetryPolicy.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/http/TestHttpRetryPolicy.java
@@ -207,6 +207,12 @@ public class TestHttpRetryPolicy {
                 new NonRetryableHttpStatusException("configuration error: 400 Bad Request")));
     }
 
+    @Test(groups = {"UNIT"})
+    public void testNonRetryableHttpStatusExceptionWithRetryKeywordIsNotRetryable() {
+        Assert.assertFalse(HttpRetryPolicy.isRetryableIOException(
+                new NonRetryableHttpStatusException("configuration error: 400 Bad Request, body=timeout")));
+    }
+
     private static String serverUrl(HttpServer server, String path) {
         return "http://127.0.0.1:" + server.getAddress().getPort() + path;
     }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/internal/session/TestDatabendSessionHandle.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/internal/session/TestDatabendSessionHandle.java
@@ -1082,7 +1082,7 @@ public class TestDatabendSessionHandle {
         }
     }
 
-    @Test(groups = {"UNIT"}, timeOut = 30000)
+    @Test(groups = {"UNIT"}, timeOut = 60000)
     public void testDownloadStreamPresignedRetryExhaustionRaisesSQLException() throws Exception {
         HttpServer queryServer = HttpServer.create(new InetSocketAddress(0), 0);
         HttpServer downloadServer = HttpServer.create(new InetSocketAddress(0), 0);
@@ -1126,7 +1126,7 @@ public class TestDatabendSessionHandle {
                     String.valueOf(exception.getCause().getCause()));
             Assert.assertTrue(exception.getCause().getCause().getMessage().contains("Presign request failed"),
                     exception.getCause().getCause().getMessage());
-            Assert.assertEquals(attempts.get(), 20);
+            Assert.assertEquals(attempts.get(), 6);
         }
         finally {
             queryServer.stop(0);


### PR DESCRIPTION
## Summary

Fixes retry behavior for presign upload/download and stage upload.

## Changes

- **MaxRetryAttempts**: 20 → 5 for both `PresignClient` and stage upload
- **Exponential backoff**: replace linear `attempts*100ms` with `min(1s * 2^n, 30s)` (max ~31s total wait across 5 retries)
- **Remove sinceStart timeout**: the 900s wall-clock check incorrectly included actual file transfer time — a large file that took 800s to transfer would exhaust retries immediately after one failure
- **Reduce timeouts**: `connectTimeout` 600s→30s, `write/readTimeout` 900s/600s→300s (300s is still generous for large files; 600s connect timeout was meaningless)
- **Fix false retry on NonRetryableHttpStatusException**: short-circuit `isRetryableIOException` before checking error keywords, preventing response bodies containing "timeout" from triggering retries
- **Remove unused `RetryableHttpFailure` class**

## Testing

Updated `testDownloadStreamPresignedRetryExhaustionRaisesSQLException` to reflect new attempt count (6) and extended timeout to 60s to accommodate exponential backoff.