### PR TITLE
fix: use TLS SSL context

### DIFF
--- a/databend-client/src/main/java/com/databend/client/OkHttpUtils.java
+++ b/databend-client/src/main/java/com/databend/client/OkHttpUtils.java
@@ -78,7 +78,7 @@ public final class OkHttpUtils {
                 }
             };
 
-            SSLContext sslContext = SSLContext.getInstance("SSL");
+            SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[]{trustAllCerts}, new SecureRandom());
 
             clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustAllCerts);

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/OkHttpUtils.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/http/OkHttpUtils.java
@@ -61,7 +61,7 @@ public final class OkHttpUtils {
                     return new X509Certificate[0];
                 }
             };
-            SSLContext sslContext = SSLContext.getInstance("SSL");
+            SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[] {trustAllCerts}, new SecureRandom());
             clientBuilder.sslSocketFactory(sslContext.getSocketFactory(), trustAllCerts);
             clientBuilder.hostnameVerifier((hostname, session) -> true);


### PR DESCRIPTION
## Summary
- Replace SSLContext protocol name from `SSL` to `TLS` in JDBC and client OkHttp utilities.
- Keep existing insecure SSL behavior unchanged to minimize compatibility risk.

## Motivation
Snyk Code reports CWE-326 for using `SSLContext.getInstance("SSL")`. Using the generic `TLS` protocol lets the JVM negotiate supported TLS versions instead of requesting the legacy SSL protocol family.

## Testing
- `git diff --check`
- `mvn -pl databend-client,databend-jdbc test -Dgroups=UNIT`
- GitHub CI will run full validation for the PR.