### PR TITLE
fix: preserve arrow memory unsafe in shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,14 @@
                             <dependencyReducedPomLocation>
                                 ${java.io.tmpdir}/dependency-reduced-pom.xml
                             </dependencyReducedPomLocation>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.arrow:arrow-memory-unsafe</artifact>
+                                    <includes>
+                                        <include>org/apache/arrow/memory/unsafe/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>com.google.common</pattern>


### PR DESCRIPTION
## Summary
- preserve Arrow memory unsafe implementation classes in the shaded JDBC jar
- keep maven-shade-plugin minimization enabled while preventing reflective allocator classes from being removed

## Motivation
Arrow loads org.apache.arrow.memory.unsafe.DefaultAllocationManagerFactory reflectively. With minimizeJar enabled, the shaded JDBC jar kept Arrow memory/vector classes but removed the arrow-memory-unsafe allocator implementation, causing Arrow mode to fail at runtime with No DefaultAllocationManager found on classpath. This change keeps the small unsafe allocator implementation in the release jar so Arrow buffers can be allocated without requiring downstream users to add arrow-memory-unsafe explicitly.

## Testing
- mvn -q -pl databend-jdbc -am package -DskipTests -Dgpg.skip=true -Dmaven.javadoc.skip=true
- verified databend-jdbc-0.4.6.jar contains org/apache/arrow/memory/unsafe/DefaultAllocationManagerFactory.class and UnsafeAllocationManager classes
- compiled and ran a minimal RootAllocator program against the shaded jar with --add-opens=java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true; output: ARROW OK org.apache.arrow.memory.RootAllocator
