### PR TITLE
bump Jackson to 2.22.1

### DIFF
--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestDatabendDatabaseMetaData.java
@@ -120,7 +120,7 @@ public class TestDatabendDatabaseMetaData {
             DatabaseMetaData metaData = connection.getMetaData();
             float majorVersion = (float) metaData.getDatabaseMajorVersion() / 10;
             int minorVersion = metaData.getDatabaseMinorVersion();
-            String checkVersion = String.format("v%.1f.%d", majorVersion, minorVersion);
+            String checkVersion = String.format(Locale.ROOT, "v%.1f.%d", majorVersion, minorVersion);
             Assert.assertTrue(metaData.getDatabaseProductVersion().contains(checkVersion));
 
             if (Compatibility.serverCapability.streamingLoad && Compatibility.driverCapability.streamingLoad) {

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dep.arrow.version>19.0.0</dep.arrow.version>
         <dep.commons-lang3.version>3.18.0</dep.commons-lang3.version>
-        <dep.jackson.annotations.version>2.21</dep.jackson.annotations.version>
-        <dep.jackson.version>2.21.2</dep.jackson.version>
+        <dep.jackson.annotations.version>2.22</dep.jackson.annotations.version>
+        <dep.jackson.version>2.22.1</dep.jackson.version>
         <dep.jsr305.version>3.0.2</dep.jsr305.version>
         <dep.guava.version>32.0.1-jre</dep.guava.version>
         <dep.slf4j.version>1.7.6</dep.slf4j.version>


### PR DESCRIPTION
• Jackson dependency upgrade (including fixes for jackson-databind 2.21.2 vulnerabilities: CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515, CVE-2026-54516, CVE-2026-54517, CVE-2026-54518)
• Locale-independent version formatting in metadata tests (1,2 → 1.2) via Locale.ROOT in String.format