### PR TITLE
fix(jdbc): preserve binary and empty prepared values

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendPreparedStatement.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendPreparedStatement.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.*;
 import java.math.BigDecimal;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.*;
 import java.time.*;
@@ -113,10 +112,6 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
         return x.toString();
     }
 
-    private static String formatBytesLiteral(byte[] x) {
-        return new String(x, StandardCharsets.UTF_8);
-    }
-
     static IllegalArgumentException invalidConversion(Object x, String toType) {
         return new IllegalArgumentException(
                 format("Cannot convert instance of %s to %s", x.getClass().getName(), toType));
@@ -188,7 +183,6 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
         }
         Map<String, String> copyOptions = new HashMap<>();
         copyOptions.put("PURGE", String.valueOf(connection.copyPurge()));
-        copyOptions.put("NULL_DISPLAY", String.valueOf(connection.nullDisplay()));
         return new StageAttachment(
                 stagePath,
                 fileFormatOptions.isEmpty() ? null : fileFormatOptions,
@@ -383,7 +377,25 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
     public void setBytes(int i, byte[] v)
             throws SQLException {
         checkOpen();
-        setValueStringNoQuote(i, formatBytesLiteral(v));
+        setBinaryValue(i, v);
+    }
+
+    private void setBinaryValue(int index, byte[] value) throws SQLException {
+        if (value == null) {
+            setValueNull(index);
+            return;
+        }
+
+        String encoded;
+        String sqlValue;
+        if (BASE64_STR.equalsIgnoreCase(connection().binaryFormat())) {
+            encoded = bytesToBase64(value);
+            sqlValue = String.format("from_base64('%s')", encoded);
+        } else {
+            encoded = bytesToHex(value);
+            sqlValue = String.format("from_hex('%s')", encoded);
+        }
+        setValue(index, sqlValue, encoded);
     }
 
     @Override
@@ -493,9 +505,6 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
                 }
                 return;
             case Types.BINARY:
-                InputStream blobInputStream = new ByteArrayInputStream(x.toString().getBytes());
-                setBinaryStream(parameterIndex, blobInputStream);
-                return;
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
                 setBytes(parameterIndex, castToBinary(x, targetSqlType));
@@ -794,14 +803,7 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
                 buffer.write(data, 0, nRead);
             }
             buffer.flush();
-            byte[] bytes = buffer.toByteArray();
-            if (BASE64_STR.equalsIgnoreCase(connection().binaryFormat())) {
-                String base64String = bytesToBase64(bytes);
-                setValueStringNoQuote(i, base64String);
-            } else {
-                String hexString = bytesToHex(bytes);
-                setValueStringNoQuote(i, hexString);
-            }
+            setBinaryValue(i, buffer.toByteArray());
         } catch (IOException e) {
             throw new SQLException("Error reading InputStream", e);
         }

--- a/databend-jdbc/src/main/java/com/databend/jdbc/internal/binding/BatchInsertContext.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/internal/binding/BatchInsertContext.java
@@ -2,6 +2,7 @@ package com.databend.jdbc.internal.binding;
 
 import de.siegmar.fastcsv.writer.CsvWriter;
 import de.siegmar.fastcsv.writer.LineDelimiter;
+import de.siegmar.fastcsv.writer.QuoteStrategy;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -96,7 +97,11 @@ public class BatchInsertContext {
         }
         // save values to csv file
         try (FileWriter pw = new FileWriter(file)) {
-            CsvWriter w = CsvWriter.builder().quoteCharacter('"').lineDelimiter(LineDelimiter.LF).build(pw);
+            CsvWriter w = CsvWriter.builder()
+                    .quoteCharacter('"')
+                    .quoteStrategy(QuoteStrategy.EMPTY)
+                    .lineDelimiter(LineDelimiter.LF)
+                    .build(pw);
             for (String[] row : values) {
                 w.writeRow(row);
             }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestBatchInsertContext.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestBatchInsertContext.java
@@ -14,7 +14,7 @@ public class TestBatchInsertContext {
     @Test(groups = "UNIT")
     public void testFiles() throws IOException {
         List<String[]> data = new ArrayList<>();
-        data.add(new String[]{"1", "2", "{\"a\": 1, \"b\": \"2\"}", "hello, world 321"});
+        data.add(new String[]{"1", "2", "{\"a\": 1, \"b\": \"2\"}", "hello, world 321", ""});
         BatchInsertContext context = new BatchInsertContext("sq");
         File f = context.saveBatchToCSV(data);
         System.out.println(f.getAbsolutePath());
@@ -22,7 +22,7 @@ public class TestBatchInsertContext {
             char[] buf = new char[1024];
             int len = fr.read(buf);
             String actual = new String(buf, 0, len);
-            String exp = "1,2,\"{\"\"a\"\": 1, \"\"b\"\": \"\"2\"\"}\",\"hello, world 321\"\n";
+            String exp = "1,2,\"{\"\"a\"\": 1, \"\"b\"\": \"\"2\"\"}\",\"hello, world 321\",\"\"\n";
             Assert.assertEquals(exp, actual);
         }
     }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestPrepareStatement.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestPrepareStatement.java
@@ -48,6 +48,108 @@ public class TestPrepareStatement {
         return c;
     }
 
+    Connection getConn(String binaryFormat) throws SQLException {
+        String dbName = DB_NAME.get();
+        try (Connection connection = Utils.createConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(String.format("create or replace database %s", dbName));
+        }
+
+        Properties properties = new Properties();
+        properties.setProperty("user", Utils.getUsername());
+        properties.setProperty("password", Utils.getPassword());
+        properties.setProperty("binary_format", binaryFormat);
+        return Utils.createConnection(dbName, properties);
+    }
+
+    @DataProvider(name = "binaryBindingModes")
+    public Object[][] binaryBindingModes() {
+        return new Object[][]{
+                {false, "hex"},
+                {true, "hex"},
+                {false, "base64"},
+                {true, "base64"},
+        };
+    }
+
+    @DataProvider(name = "preparedStatementModes")
+    public Object[][] preparedStatementModes() {
+        return new Object[][]{
+                {false},
+                {true},
+        };
+    }
+
+    @Test(groups = "IT", dataProvider = "preparedStatementModes")
+    public void testEmptyStringRoundTrip(boolean batch) throws SQLException {
+        try (Connection connection = getConn();
+             Statement statement = connection.createStatement()) {
+            statement.execute("create table t_empty_string(id int, v string)");
+
+            try (PreparedStatement preparedStatement = connection.prepareStatement(
+                    "insert into t_empty_string values (?, ?)")) {
+                preparedStatement.setInt(1, 1);
+                preparedStatement.setString(2, "");
+                if (batch) {
+                    preparedStatement.addBatch();
+                    Assert.assertEquals(preparedStatement.executeBatch(), new int[]{1});
+                } else {
+                    Assert.assertEquals(preparedStatement.executeUpdate(), 1);
+                }
+            }
+
+            try (ResultSet resultSet = statement.executeQuery("select v from t_empty_string")) {
+                Assert.assertTrue(resultSet.next());
+                Assert.assertEquals(resultSet.getString(1), "");
+                Assert.assertFalse(resultSet.next());
+            }
+        }
+    }
+
+    @Test(groups = "IT", dataProvider = "binaryBindingModes")
+    public void testSetBytesRoundTrip(boolean batch, String binaryFormat) throws SQLException {
+        byte[][] values = new byte[][]{
+                {0x00, (byte) 0xff, 0x27, 0x61, 0x5c},
+                null,
+        };
+
+        try (Connection connection = getConn(binaryFormat);
+             Statement statement = connection.createStatement()) {
+            statement.execute("create table t1(id int, v binary)");
+
+            if (batch) {
+                try (PreparedStatement preparedStatement = connection.prepareStatement("insert into t1 values (?, ?)")) {
+                    for (int i = 0; i < values.length; i++) {
+                        preparedStatement.setInt(1, i + 1);
+                        preparedStatement.setBytes(2, values[i]);
+                        preparedStatement.addBatch();
+                    }
+                    Assert.assertEquals(preparedStatement.executeBatch(), new int[]{1, 1});
+                }
+            } else {
+                try (PreparedStatement preparedStatement = connection.prepareStatement("insert into t1 values (?, ?)")) {
+                    for (int i = 0; i < values.length; i++) {
+                        preparedStatement.setInt(1, i + 1);
+                        preparedStatement.setBytes(2, values[i]);
+                        Assert.assertEquals(preparedStatement.executeUpdate(), 1);
+                    }
+                }
+            }
+
+            try (ResultSet resultSet = statement.executeQuery(
+                    "select id, lower(to_hex(v)) from t1 order by id")) {
+                Assert.assertTrue(resultSet.next());
+                Assert.assertEquals(resultSet.getInt(1), 1);
+                Assert.assertEquals(resultSet.getString(2), "00ff27615c");
+
+                Assert.assertTrue(resultSet.next());
+                Assert.assertEquals(resultSet.getInt(1), 2);
+                Assert.assertNull(resultSet.getString(2));
+                Assert.assertFalse(resultSet.next());
+            }
+        }
+    }
+
     @Test(groups = "IT")
     public void TestBatchInsert() throws SQLException {
         Statement s;
@@ -411,7 +513,7 @@ public class TestPrepareStatement {
             Assert.assertFalse(stageAttachment.getFileFormatOptions().containsKey("binary_format"));
             Assert.assertTrue(stageAttachment.getFileFormatOptions().containsKey("type"));
             Assert.assertEquals("true", stageAttachment.getCopyOptions().get("PURGE"));
-            Assert.assertEquals("\\N", stageAttachment.getCopyOptions().get("NULL_DISPLAY"));
+            Assert.assertFalse(stageAttachment.getCopyOptions().containsKey("NULL_DISPLAY"));
         }
     }
 
@@ -431,7 +533,8 @@ public class TestPrepareStatement {
             Assert.assertEquals(stageAttachment.getFileFormatOptions().get("binary_format"), "base64");
             Assert.assertEquals(stageAttachment.getFileFormatOptions().get("type"), "CSV");
             Assert.assertEquals(stageAttachment.getCopyOptions().get("PURGE"), "false");
-            Assert.assertEquals(stageAttachment.getCopyOptions().get("NULL_DISPLAY"), "NULL");
+            Assert.assertFalse(stageAttachment.getCopyOptions().containsKey("NULL_DISPLAY"));
+            Assert.assertFalse(stageAttachment.getFileFormatOptions().containsKey("null_display"));
         }
     }
 

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestPreparedStatementBytes.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestPreparedStatementBytes.java
@@ -1,0 +1,112 @@
+package com.databend.jdbc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import okhttp3.OkHttpClient;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.sql.PreparedStatement;
+import java.sql.Types;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TestPreparedStatementBytes {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final byte[] BINARY_VALUE = new byte[]{0x00, (byte) 0xff, 0x27, 0x61, 0x5c};
+
+    @Test(groups = {"UNIT"})
+    public void testSetBytesUsesHexLiteralByDefault() throws Exception {
+        String sql = captureSql(null, statement -> statement.setBytes(1, BINARY_VALUE));
+
+        Assert.assertEquals(sql, "select from_hex('00ff27615c')");
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testSetBytesUsesConfiguredBase64Literal() throws Exception {
+        String sql = captureSql("base64", statement -> statement.setBytes(1, BINARY_VALUE));
+
+        Assert.assertEquals(sql, "select from_base64('AP8nYVw=')");
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testSetBytesSupportsNull() throws Exception {
+        String sql = captureSql(null, statement -> statement.setBytes(1, null));
+
+        Assert.assertEquals(sql, "select null");
+    }
+
+    @Test(groups = {"UNIT"})
+    public void testBinarySettersShareLosslessEncoding() throws Exception {
+        String streamSql = captureSql(null, statement -> statement.setBinaryStream(
+                1, new ByteArrayInputStream(BINARY_VALUE)));
+        String objectSql = captureSql(null, statement -> statement.setObject(1, BINARY_VALUE, Types.BINARY));
+
+        Assert.assertEquals(streamSql, "select from_hex('00ff27615c')");
+        Assert.assertEquals(objectSql, "select from_hex('00ff27615c')");
+    }
+
+    private static String captureSql(String binaryFormat, StatementBinder binder) throws Exception {
+        AtomicReference<String> requestBody = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/v1/session/login", exchange -> sendJson(exchange,
+                "{\"version\":\"1.2.100\",\"server_max_arrow_result_version\":2}"));
+        server.createContext("/v1/query", exchange -> {
+            requestBody.set(new String(readAllBytes(exchange.getRequestBody()), StandardCharsets.UTF_8));
+            sendJson(exchange, "{\"id\":\"qid\",\"node_id\":\"node\","
+                    + "\"session\":{\"database\":\"default\"},\"schema\":[],\"data\":[]}");
+        });
+        server.start();
+
+        try {
+            Properties properties = new Properties();
+            properties.setProperty("presigned_url_disabled", "true");
+            if (binaryFormat != null) {
+                properties.setProperty("binary_format", binaryFormat);
+            }
+            DatabendDriverUri uri = DatabendDriverUri.create(
+                    "jdbc:databend://root@127.0.0.1:" + server.getAddress().getPort() + "/default",
+                    properties);
+            try (DatabendConnection connection = new DatabendConnection(uri, new OkHttpClient());
+                 PreparedStatement statement = connection.prepareStatement("select ?")) {
+                binder.bind(statement);
+                statement.execute();
+            }
+            return OBJECT_MAPPER.readTree(requestBody.get()).get("sql").asText();
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static byte[] readAllBytes(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int read;
+        while ((read = inputStream.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static void sendJson(HttpExchange exchange, String body) throws IOException {
+        byte[] response = body.getBytes(StandardCharsets.UTF_8);
+        try {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private interface StatementBinder {
+        void bind(PreparedStatement statement) throws Exception;
+    }
+}


### PR DESCRIPTION
## Motivation

`PreparedStatement.setBytes` decoded arbitrary byte arrays as UTF-8 and substituted the result into SQL without quoting. This could corrupt non-UTF-8 data, produce invalid SQL, and throw a `NullPointerException` for null values. The binary path used by `setObject(..., Types.BINARY)` also converted the Java array object's string representation instead of its contents. In attachment batches, unquoted empty CSV fields also caused empty strings to be loaded as SQL `NULL`.

## Summary

- encode byte arrays losslessly as hex or base64 and bind them with `from_hex` or `from_base64`
- share the same binary binding path across `setBytes`, `setBinaryStream`, and binary `setObject` calls
- support null byte array bindings
- quote empty CSV fields so batched empty strings remain empty strings
- stop sending `NULL_DISPLAY` as an attachment copy option because Databend ignores it; retain the default `\N` CSV null marker
- add request-level unit tests and Databend round-trip integration coverage for hex/base64 and direct/batch execution

## Testing

- `mvn -pl databend-jdbc -Dgroups=UNIT -Dtest=TestPreparedStatementBytes,TestPrepareStatement,TestBatchInsertContext test`
- `mvn -pl databend-jdbc -Dgroups=IT '-Dtest=TestPrepareStatement#testSetBytesRoundTrip+testEmptyStringRoundTrip' test`

## Risk

Low. Binary values now use explicit Databend conversion functions, and empty CSV fields are quoted. Empty Binary values in attachment batches remain subject to Databend's CSV decoding semantics and are not handled specially by the JDBC client.

## Breaking changes

None.
