### PR TITLE
feat: release 0.4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add following code block as a dependency
 <dependency>
     <groupId>com.databend</groupId>
     <artifactId>databend-jdbc</artifactId>
-    <version>0.4.8</version>
+    <version>0.4.9</version>
 </dependency>
 ```
 

--- a/databend-client/pom.xml
+++ b/databend-client/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.databend</groupId>
         <artifactId>databend-base</artifactId>
-        <version>0.4.8</version>
+        <version>0.4.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>com.databend</groupId>
     <artifactId>databend-client</artifactId>
-    <version>0.4.8</version>
+    <version>0.4.9</version>
     <name>databend-client</name>
     <packaging>jar</packaging>
 

--- a/databend-jdbc/pom.xml
+++ b/databend-jdbc/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.databend</groupId>
         <artifactId>databend-base</artifactId>
-        <version>0.4.8</version>
+        <version>0.4.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>databend-jdbc</artifactId>
-    <version>0.4.8</version>
+    <version>0.4.9</version>
     <name>databend-jdbc</name>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.databend</groupId>
     <artifactId>databend-base</artifactId>
-    <version>0.4.8</version>
+    <version>0.4.9</version>
     <name>databend-base</name>
     <description>Databend</description>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Motivation

Publish the JDBC fixes merged after `0.4.8`, including lossless binary prepared-statement bindings and correct empty-string handling for attachment batches.

## Summary

- bump the root Maven project version to `0.4.9`
- bump `databend-client` and `databend-jdbc` parent/artifact versions to `0.4.9`
- update the README dependency example to `0.4.9`

## Testing

- `mvn clean install -DskipTests`

## Risk

Low. This PR only updates release version metadata.

## Breaking changes

None.
