### PR TITLE
ci: fix Maven Central release credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release Workflow
 
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to publish
+        required: true
+        type: string
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -28,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -36,7 +42,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import


### PR DESCRIPTION
## Summary

- align the setup-java Maven server ID with the Central Publishing plugin
- add a manual workflow input so an existing release tag can be retried without moving the tag

## Motivation

The v0.4.9 Maven Central release failed because setup-java generated credentials for `ossrh`, while the Central Publishing plugin looks up server ID `central`. This makes the configured credentials unavailable to the plugin. A manual ref input is also needed to safely retry the existing tag after fixing the workflow.

## Testing

- `git diff --check`
- verified the workflow uses `central` consistently with `publishingServerId`

## Risk

Low. This only changes the release workflow configuration.
