### PR TITLE
ci: restrict manual releases to tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Release Workflow
 
 on:
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to publish
-        required: true
-        type: string
+  repository_dispatch:
+    types: [release_retry]
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -31,10 +27,20 @@ jobs:
           - 8000:8000
           - 9000:9000
     steps:
+      - name: Validate requested release tag
+        if: github.event_name == 'repository_dispatch'
+        env:
+          RELEASE_TAG: ${{ github.event.client_payload.tag }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+            echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'repository_dispatch' && format('refs/tags/{0}', github.event.client_payload.tag) || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary

- run release retries through `repository_dispatch`, which always uses the default-branch workflow
- validate requested release tags before checkout
- reject branches, commit SHAs, and malformed release refs
- checkout retries through an explicit `refs/tags/` ref

## Motivation

Follow-up to the security reviews on #412 and #413: `workflow_dispatch` allows selecting the ref that supplies the workflow itself, so validating only the checkout ref still lets a modified branch workflow access release credentials. `repository_dispatch` removes that selectable workflow ref and runs the trusted default-branch workflow, while the validated payload identifies the protected release tag to retry.

Review context: https://github.com/databendlabs/databend-jdbc/pull/412#discussion_r3719453510

Follow-up review: https://github.com/databendlabs/databend-jdbc/pull/413#discussion_r3719939743

## Testing

- `git diff --check`
- accepted `v0.4.9` and `v1.2.3-rc1`
- rejected `main`, a commit-like SHA, incomplete versions, and non-release suffixes

## Risk

Low. Normal tag-push releases are unchanged; release retries move from the UI dispatch form to the repository dispatch API so the workflow source cannot be overridden.
