### PR TITLE
fix: avoid shaded packages in test code

### DIFF
--- a/databend-jdbc/src/test/java/com/databend/jdbc/StatementUtilTest.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/StatementUtilTest.java
@@ -3,9 +3,9 @@ package com.databend.jdbc;
 import com.databend.jdbc.internal.binding.RawStatementWrapper;
 import com.databend.jdbc.internal.binding.StatementUtil;
 import com.databend.jdbc.internal.binding.StatementType;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static com.databend.jdbc.internal.binding.StatementUtil.replaceParameterMarksWithValues;
@@ -15,7 +15,7 @@ public class StatementUtilTest {
     @Test
     void shouldGetAllQueryParamsFromIn() {
         String sql = "SElECT * FROM EMPLOYEES WHERE id IN (?,?)";
-        assertEquals(ImmutableMap.of(1, 37, 2, 39), StatementUtil.getParamMarketsPositions(sql));
+        assertEquals(mapOf(1, 37, 2, 39), StatementUtil.getParamMarketsPositions(sql));
         System.out.println(StatementUtil.parseToRawStatementWrapper(sql).getSubStatements());
         assertEquals(1, StatementUtil.parseToRawStatementWrapper(sql).getSubStatements().size());
     }
@@ -23,7 +23,7 @@ public class StatementUtilTest {
     @Test
     void shouldGetAllQueryParams() {
         String sql = "SElECT * FROM EMPLOYEES WHERE id = ?";
-        assertEquals(ImmutableMap.of(1, 35), StatementUtil.getParamMarketsPositions(sql));
+        assertEquals(mapOf(1, 35), StatementUtil.getParamMarketsPositions(sql));
         assertEquals(1, StatementUtil.parseToRawStatementWrapper(sql).getSubStatements().size());
     }
 
@@ -31,7 +31,7 @@ public class StatementUtilTest {
     void shouldReplaceAQueryParam() {
         String sql = "SElECT * FROM EMPLOYEES WHERE id is ?";
         String expectedSql = "SElECT * FROM EMPLOYEES WHERE id is 5";
-        Map<Integer, String> params = ImmutableMap.of(1, "5");
+        Map<Integer, String> params = mapOf(1, "5");
         System.out.println(replaceParameterMarksWithValues(params, sql));
         assertEquals(expectedSql, replaceParameterMarksWithValues(params, sql).get(0).getSql());
     }
@@ -40,7 +40,7 @@ public class StatementUtilTest {
     void shouldReplaceMultipleQueryParams() {
         String sql = "SElECT * FROM EMPLOYEES WHERE id = ? AND name LIKE ? AND dob = ? ";
         String expectedSql = "SElECT * FROM EMPLOYEES WHERE id = 5 AND name LIKE 'George' AND dob = '1980-05-22' ";
-        Map<Integer, String> params = ImmutableMap.of(1, "5", 2, "'George'", 3, "'1980-05-22'");
+        Map<Integer, String> params = mapOf(1, "5", 2, "'George'", 3, "'1980-05-22'");
         assertEquals(expectedSql, replaceParameterMarksWithValues(params, sql).get(0).getSql());
     }
 
@@ -76,5 +76,14 @@ public class StatementUtilTest {
         assertEquals(false, StatementUtil.isQuery("settings (timezone='UTC') insert into t values (?)"));
         assertEquals(false, StatementUtil.isQuery("WITH src AS (SELECT 1) INSERT INTO t VALUES (?)"));
         assertEquals(false, StatementUtil.isQuery("insert into t values (?)"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <K, V> Map<K, V> mapOf(Object... keyValues) {
+        Map<K, V> map = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            map.put((K) keyValues[i], (V) keyValues[i + 1]);
+        }
+        return map;
     }
 }

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestPreparedStatementBytes.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestPreparedStatementBytes.java
@@ -1,6 +1,5 @@
 package com.databend.jdbc;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import okhttp3.OkHttpClient;
@@ -19,7 +18,6 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestPreparedStatementBytes {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final byte[] BINARY_VALUE = new byte[]{0x00, (byte) 0xff, 0x27, 0x61, 0x5c};
 
     @Test(groups = {"UNIT"})
@@ -79,10 +77,59 @@ public class TestPreparedStatementBytes {
                 binder.bind(statement);
                 statement.execute();
             }
-            return OBJECT_MAPPER.readTree(requestBody.get()).get("sql").asText();
+            return extractJsonStringField(requestBody.get(), "sql");
         } finally {
             server.stop(0);
         }
+    }
+
+    /**
+     * Minimal JSON string-field reader. The test jar is executed against the shaded driver jar,
+     * where Jackson is relocated, so tests must not depend on {@code com.fasterxml.jackson}.
+     */
+    private static String extractJsonStringField(String json, String field) {
+        String marker = "\"" + field + "\":\"";
+        int start = json.indexOf(marker);
+        Assert.assertTrue(start >= 0, "field " + field + " not found in " + json);
+        start += marker.length();
+
+        StringBuilder value = new StringBuilder();
+        for (int i = start; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (c == '"') {
+                return value.toString();
+            }
+            if (c != '\\') {
+                value.append(c);
+                continue;
+            }
+            char escaped = json.charAt(++i);
+            switch (escaped) {
+                case 'n':
+                    value.append('\n');
+                    break;
+                case 'r':
+                    value.append('\r');
+                    break;
+                case 't':
+                    value.append('\t');
+                    break;
+                case 'b':
+                    value.append('\b');
+                    break;
+                case 'f':
+                    value.append('\f');
+                    break;
+                case 'u':
+                    value.append((char) Integer.parseInt(json.substring(i + 1, i + 5), 16));
+                    i += 4;
+                    break;
+                default:
+                    value.append(escaped);
+                    break;
+            }
+        }
+        throw new IllegalArgumentException("unterminated string for field " + field + " in " + json);
     }
 
     private static byte[] readAllBytes(InputStream inputStream) throws IOException {

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestResultCursor.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestResultCursor.java
@@ -8,7 +8,6 @@ import com.databend.jdbc.internal.query.ResultPage;
 import com.databend.jdbc.internal.session.Capability;
 import com.databend.jdbc.internal.session.QueryLiveness;
 import com.databend.jdbc.internal.session.SessionState;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.vdurmont.semver4j.Semver;
 import okhttp3.Request;
 import org.testng.Assert;
@@ -19,12 +18,15 @@ import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -58,7 +60,7 @@ public class TestResultCursor {
         FakePage empty2 = new FakePage(Collections.emptyList(), closedPages);
         FakePage page2 = new FakePage(Collections.singletonList(Collections.singletonList(3)), closedPages);
 
-        ExecutorService executor = MoreExecutors.newDirectExecutorService();
+        ExecutorService executor = new DirectExecutorService();
         try {
             DatabendResultSet.PrefetchingPageSource pageSource = new DatabendResultSet.PrefetchingPageSource(
                     new FakeQueryResultPages(Arrays.asList(empty1, page1, empty2, page2), successResults(), successResults()),
@@ -81,7 +83,7 @@ public class TestResultCursor {
         FakePage page1 = new FakePage(Collections.singletonList(Collections.singletonList(1)), closedPages);
         FakePage page2 = new FakePage(Collections.singletonList(Collections.singletonList(2)), closedPages);
 
-        ExecutorService executor = MoreExecutors.newDirectExecutorService();
+        ExecutorService executor = new DirectExecutorService();
         try {
             DatabendResultSet.PrefetchingPageSource pageSource = new DatabendResultSet.PrefetchingPageSource(
                     new FakeQueryResultPages(Arrays.asList(page1, page2), successResults(), successResults()),
@@ -119,7 +121,7 @@ public class TestResultCursor {
                 URI.create("/v1/query/final"),
                 null);
 
-        ExecutorService executor = MoreExecutors.newDirectExecutorService();
+        ExecutorService executor = new DirectExecutorService();
         try {
             DatabendResultSet.PrefetchingPageSource pageSource = new DatabendResultSet.PrefetchingPageSource(
                     new FakeQueryResultPages(Collections.singletonList(page1), successResults(), errorResults),
@@ -270,6 +272,45 @@ public class TestResultCursor {
                     }
                     return null;
                 });
+    }
+
+    /**
+     * Runs submitted tasks on the calling thread. The published test jar is executed against the
+     * shaded driver jar, where Guava is relocated, so tests must not depend on {@code com.google.common}.
+     */
+    private static final class DirectExecutorService extends AbstractExecutorService {
+        private volatile boolean shutdown;
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return new ArrayList<>();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) {
+            return shutdown;
+        }
     }
 
     private static final class FakePage implements ResultPage {


### PR DESCRIPTION
The published tests jar runs against the shaded driver jar, where jackson
    and guava are relocated, so test references to the original package names
    fail with NoClassDefFoundError. TestPreparedStatementBytes held ObjectMapper
    in a static field and broke the whole suite at <clinit>; the guava uses in
    StatementUtilTest and TestResultCursor were latent. Replace all three with
    JDK APIs or local test helpers.