### PR TITLE
feat: release 0.4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add following code block as a dependency
 <dependency>
     <groupId>com.databend</groupId>
     <artifactId>databend-jdbc</artifactId>
-    <version>0.4.9</version>
+    <version>0.4.10</version>
 </dependency>
 ```
 

--- a/databend-client/pom.xml
+++ b/databend-client/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.databend</groupId>
         <artifactId>databend-base</artifactId>
-        <version>0.4.9</version>
+        <version>0.4.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>com.databend</groupId>
     <artifactId>databend-client</artifactId>
-    <version>0.4.9</version>
+    <version>0.4.10</version>
     <name>databend-client</name>
     <packaging>jar</packaging>
 

--- a/databend-jdbc/pom.xml
+++ b/databend-jdbc/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>com.databend</groupId>
         <artifactId>databend-base</artifactId>
-        <version>0.4.9</version>
+        <version>0.4.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>databend-jdbc</artifactId>
-    <version>0.4.9</version>
+    <version>0.4.10</version>
     <name>databend-jdbc</name>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.databend</groupId>
     <artifactId>databend-base</artifactId>
-    <version>0.4.9</version>
+    <version>0.4.10</version>
     <name>databend-base</name>
     <description>Databend</description>
     <packaging>pom</packaging>


### PR DESCRIPTION
## Summary

- bump the parent, client, and JDBC module versions to `0.4.10`
- update the README dependency example to `0.4.10`

## Motivation

Prepare the next patch release from the latest `main`, including the release workflow hardening and the shaded-package test fix merged after `0.4.9`.

## Testing

- `mvn clean install -DskipTests`
- all three reactor modules built successfully as `0.4.10`
- Checkstyle completed with zero violations

## Risk

Low. This PR only updates release version references.
