### PR TITLE
revert: roll back release workflow changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release Workflow
 
 on:
-  repository_dispatch:
-    types: [release_retry]
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -27,20 +25,10 @@ jobs:
           - 8000:8000
           - 9000:9000
     steps:
-      - name: Validate requested release tag
-        if: github.event_name == 'repository_dispatch'
-        env:
-          RELEASE_TAG: ${{ github.event.client_payload.tag }}
-        run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
-            echo "::error::Invalid release tag: $RELEASE_TAG"
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'repository_dispatch' && format('refs/tags/{0}', github.event.client_payload.tag) || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -48,7 +36,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-          server-id: central
+          server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import


### PR DESCRIPTION
## Summary

- revert the release retry changes from #413
- revert the Maven server ID and manual retry changes from #412
- restore `.github/workflows/release.yml` to its pre-#412 state

## Motivation

Roll back the recent release workflow changes while the Maven Central and retry design is reconsidered. The release workflow returns to tag-push-only behavior.

## Testing

- `git diff --cached --check`
- verified `release.yml` matches the version before #412 exactly

## Risk

The workflow will provision credentials under server ID `ossrh` again while the Central Publishing plugin requests `central`, so automated Maven Central publishing may reproduce the previous missing-server failure. Manual release retries are also removed.
