### PR TITLE
test: simulate release-jar layout in compat tests

### DIFF
--- a/.github/workflows/test_compatibility.yml
+++ b/.github/workflows/test_compatibility.yml
@@ -1,0 +1,95 @@
+name: Compatibility Test
+
+# databend's compat CI consumes our published jars directly: the shaded driver jar
+# plus the -tests jar on a bare classpath, driven by TestNG. 'mvn test' does not
+# reproduce that classpath, so breakage used to surface only after a release and
+# blocked databend CI until a hotfix release went out (#414).
+#
+# These jobs simulate the release-jar layout against main on every PR.
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-jar-deps:
+    name: Test jar resolves on release classpath
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Check test jar dependencies
+        working-directory: tests
+        run: make compat-check
+
+  release-jar-tests:
+    name: Run IT suite from release jars
+    runs-on: ubuntu-latest
+    services:
+      databend:
+        image: datafuselabs/databend:nightly
+        env:
+          QUERY_DEFAULT_USER: databend
+          QUERY_DEFAULT_PASSWORD: databend
+          MINIO_ENABLED: true
+        ports:
+          - 8000:8000
+          - 9000:9000
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'maven'
+
+      - name: Verify Service Running
+        run: |
+          sleep 30
+          cid=$(docker ps -a | grep databend | cut -d' ' -f1)
+          docker logs ${cid}
+          curl -u databend:databend --request POST localhost:8000/v1/query --header 'Content-Type:application/json' --data-raw '{"sql":"select 1"}'
+
+      - name: Run IT Tests from release jars
+        working-directory: tests
+        run: make compat-test
+
+      # databend's compat CI only selects groups=IT, so UNIT classes never get
+      # loaded there. #414 broke exactly those classes, so load them here too.
+      # Runs even when the IT pass failed, to report both in one go.
+      - name: Run UNIT Tests from release jars
+        if: ${{ !cancelled() }}
+        working-directory: tests
+        env:
+          COMPAT_SKIP_BUILD: "1"
+          COMPAT_GROUPS: UNIT
+          COMPAT_EXCLUDED_GROUPS: FLAKY,UNIT_ARROW,cluster,MULTI_HOST
+        run: make compat-test
+
+      - name: Upload test output
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: compat-test-output
+          path: tests/compatibility/test-output
+          retention-days: 7
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ target/
 .databend/
 tests/data
 tests/compatibility/*.jar
+tests/compatibility/lib/
+tests/compatibility/generated/
 test-output
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -78,6 +78,50 @@ CI note:
 - `Standalone Test` runs the regular suite and an extra Arrow IT pass.
 - `Cluster Tests` runs the regular suite and an extra Arrow IT pass for each cluster matrix entry.
 
+### Compatibility tests against release-style jars
+
+Downstream projects (databend's compat CI in particular) do not use Maven to run our
+tests. They put the shaded driver jar and the `-tests` jar on a bare classpath and
+invoke TestNG directly. `mvn test` cannot catch problems in that setup, because
+Maven's test classpath exposes dependencies that the shaded jar relocates or drops.
+That gap is how a broken `-tests` jar reached a release and blocked databend CI until
+a hotfix release was published.
+
+Two targets simulate the release-jar layout against your working tree:
+
+```shell
+cd tests
+
+# Static check, no server needed: every class the -tests jar references must
+# resolve against the shaded driver jar plus the third-party jars downstream
+# compat suites provide.
+make compat-check
+
+# Runtime check: run the IT suite off the release-style classpath instead of Maven.
+make up
+make compat-test
+```
+
+Both build the jars first. Set `COMPAT_SKIP_BUILD=1` to reuse whatever is already in
+`databend-jdbc/target`. `compat-test` accepts `COMPAT_GROUPS` and
+`COMPAT_EXCLUDED_GROUPS` (defaults `IT` and `FLAKY,cluster,MULTI_HOST`) and honours
+`DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT=arrow`. Reports land in
+`tests/compatibility/test-output/<groups>/`, one directory per group selection, so an
+IT pass and a UNIT pass do not overwrite each other:
+
+```shell
+make compat-test COMPAT_GROUPS=UNIT COMPAT_EXCLUDED_GROUPS=FLAKY,UNIT_ARROW
+```
+
+Practical rule for test code: never import anything the shade plugin relocates
+(Jackson, Guava, SLF4J, commons-lang3). Use JDK APIs, TestNG, or the small set of
+jars listed in `tests/compatibility/common.sh`. `make compat-check` enforces this.
+
+CI runs both as the `Compatibility Test` workflow on every PR: the static check on its
+own runner, then IT and UNIT passes off the release-style classpath. databend's compat
+CI only selects `groups=IT`, so the extra UNIT pass exists to load the classes it never
+touches. The regular `mvn test` workflows are unchanged.
+
 ### Download jar from maven central
 
 ```shell

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,3 +28,14 @@ test:
 	JAVA_TOOL_OPTIONS='$(TEST_JAVA_TOOL_OPTIONS)' \
 	DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT='$(DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT)' \
 	mvn -pl databend-jdbc test $(TEST_MVN_ARGS)
+
+# Static gate: the -tests jar must resolve against the shaded driver jar plus the
+# third-party jars downstream compat suites provide. Needs no server.
+compat-check:
+	./compatibility/check_test_jar_deps.sh
+
+# Runtime gate: run the suite off the release-style classpath instead of Maven.
+# Requires a reachable Databend server (make up).
+compat-test:
+	DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT='$(DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT)' \
+	./compatibility/run_release_jar_tests.sh

--- a/tests/compatibility/check_test_jar_deps.sh
+++ b/tests/compatibility/check_test_jar_deps.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Static gate: every class the -tests jar references must be resolvable from the
+# shaded driver jar, the JDK, and the small set of third-party jars downstream
+# compat suites put on the classpath.
+#
+# This is the cheap version of the release-jar run: it needs no Databend server,
+# so it can run on every PR and catch test code that only compiles because
+# Maven's test classpath happens to expose a shaded dependency.
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+compat_build_jars
+compat_download_libs
+
+MAIN_JAR="$(compat_main_jar)"
+TEST_JAR="$(compat_test_jar)"
+MULTI_RELEASE="$(compat_multi_release)"
+
+compat_log "driver jar: ${MAIN_JAR}"
+compat_log "test jar:   ${TEST_JAR}"
+
+JDEPS_OUTPUT="$(mktemp)"
+JDEPS_STDERR="$(mktemp)"
+trap 'rm -f "${JDEPS_OUTPUT}" "${JDEPS_STDERR}"' EXIT
+
+set +e
+jdeps \
+    --multi-release "${MULTI_RELEASE:-base}" \
+    -verbose:class \
+    --class-path "${MAIN_JAR}:${COMPAT_LIB_DIR}/*" \
+    "${TEST_JAR}" >"${JDEPS_OUTPUT}" 2>"${JDEPS_STDERR}"
+JDEPS_EXIT=$?
+set -e
+
+# jdeps reports unresolved classes on stdout and still exits 0. A non-zero exit
+# means jdeps itself could not run, which must not be mistaken for a clean check.
+if [ "${JDEPS_EXIT}" -ne 0 ]; then
+    echo "jdeps failed with exit ${JDEPS_EXIT}:" >&2
+    cat "${JDEPS_STDERR}" >&2
+    exit 1
+fi
+
+if ! grep -q "$(basename "${TEST_JAR}")" "${JDEPS_OUTPUT}"; then
+    echo "jdeps produced no dependency records for ${TEST_JAR}" >&2
+    exit 1
+fi
+
+# Class-level misses look like:
+#   com.databend.jdbc.StatementUtilTest -> com.google.common.collect.ImmutableMap not found
+# The archive-level "<jar> -> not found" summary line is dropped by $3 != "not".
+MISSING="$(awk '$2 == "->" && $NF == "found" && $(NF-1) == "not" && $3 != "not" { print "  " $1 " -> " $3 }' "${JDEPS_OUTPUT}" | sort -u)"
+
+RELOCATED=""
+for prefix in ${COMPAT_RELOCATED_PREFIXES}; do
+    hits="$(awk -v p="${prefix}." '$2 == "->" && index($3, p) == 1 { print "  " $1 " -> " $3 }' "${JDEPS_OUTPUT}" | sort -u)"
+    if [ -n "${hits}" ]; then
+        RELOCATED="${RELOCATED}${hits}
+"
+    fi
+done
+
+STATUS=0
+
+if [ -n "${MISSING}" ]; then
+    echo
+    echo "Test jar references classes that are not on the release classpath:"
+    echo "${MISSING}"
+    echo
+    echo "These tests pass under 'mvn test' but fail once the -tests jar runs against"
+    echo "the shaded driver jar. Replace the dependency with JDK APIs or with something"
+    echo "the driver jar exposes unrelocated."
+    STATUS=1
+fi
+
+if [ -n "${RELOCATED}" ]; then
+    echo
+    echo "Test jar references shade-relocated packages:"
+    printf '%s' "${RELOCATED}"
+    echo
+    echo "Relocated names are an implementation detail of the shaded jar and change"
+    echo "between releases. Use the original package or a JDK API instead."
+    STATUS=1
+fi
+
+if [ "${STATUS}" -eq 0 ]; then
+    compat_log "test jar resolves against the release classpath"
+fi
+
+exit "${STATUS}"

--- a/tests/compatibility/common.sh
+++ b/tests/compatibility/common.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Shared helpers for the release-jar compatibility harness.
+#
+# The harness reproduces how downstream projects (notably databend's compat CI)
+# consume our artifacts: the shaded driver jar plus the -tests jar are put on a
+# bare classpath and TestNG is invoked directly. Maven's test classpath is not
+# involved, so anything the test code pulls from a provided/relocated dependency
+# blows up here the same way it blows up after a release.
+
+set -euo pipefail
+
+COMPAT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${COMPAT_DIR}/../.." && pwd)"
+JDBC_TARGET_DIR="${REPO_ROOT}/databend-jdbc/target"
+COMPAT_LIB_DIR="${COMPAT_DIR}/lib"
+COMPAT_GENERATED_DIR="${COMPAT_DIR}/generated"
+COMPAT_OUTPUT_ROOT="${COMPAT_DIR}/test-output"
+
+# Mirrors JDBC_TEST_LIBS in databend/tests/nox/noxfile.py, minus the JUnit console
+# launcher (TestNG suites do not need it). Keeping this list narrow keeps the check
+# strict: anything not here and not in the driver jar is a release-time failure.
+COMPAT_LIB_URLS="
+https://repo.maven.apache.org/maven2/org/testng/testng/7.11.0/testng-7.11.0.jar
+https://repo1.maven.org/maven2/com/vdurmont/semver4j/3.1.0/semver4j-3.1.0.jar
+https://repo1.maven.org/maven2/org/jcommander/jcommander/1.83/jcommander-1.83.jar
+https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.19.0/jts-core-1.19.0.jar
+https://repo1.maven.org/maven2/org/slf4j/slf4j-api/2.0.16/slf4j-api-2.0.16.jar
+https://repo1.maven.org/maven2/org/slf4j/slf4j-simple/2.0.13/slf4j-simple-2.0.13.jar
+"
+
+# Packages the shade plugin relocates. Test code must never reference them.
+COMPAT_RELOCATED_PREFIXES="
+com.databend.jdbc.com.fasterxml.jackson
+com.databend.jdbc.org.slf4j
+com.databend.jdbc.org.apache.commons.lang3
+com.google.shaded.common
+"
+
+compat_log() {
+    echo "[compat] $*"
+}
+
+compat_build_jars() {
+    if [ "${COMPAT_SKIP_BUILD:-}" = "1" ]; then
+        compat_log "COMPAT_SKIP_BUILD=1, reusing jars in ${JDBC_TARGET_DIR}"
+        return
+    fi
+
+    compat_log "packaging shaded driver jar and test jar"
+    (cd "${REPO_ROOT}" && mvn -B -ntp clean package -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true)
+}
+
+# Echoes the shaded driver jar, skipping the sources/tests/javadoc/pre-shade ones.
+compat_main_jar() {
+    local jar
+    for jar in "${JDBC_TARGET_DIR}"/databend-jdbc-*.jar; do
+        [ -e "${jar}" ] || continue
+        case "$(basename "${jar}")" in
+            original-*|*-sources.jar|*-tests.jar|*-javadoc.jar) continue ;;
+        esac
+        echo "${jar}"
+        return
+    done
+    echo "no driver jar found in ${JDBC_TARGET_DIR}, run mvn package first" >&2
+    return 1
+}
+
+compat_test_jar() {
+    local jar
+    for jar in "${JDBC_TARGET_DIR}"/databend-jdbc-*-tests.jar; do
+        [ -e "${jar}" ] || continue
+        echo "${jar}"
+        return
+    done
+    echo "no test jar found in ${JDBC_TARGET_DIR}, run mvn package first" >&2
+    return 1
+}
+
+compat_download_libs() {
+    mkdir -p "${COMPAT_LIB_DIR}"
+    local url filename
+    for url in ${COMPAT_LIB_URLS}; do
+        filename="$(basename "${url}")"
+        if [ -f "${COMPAT_LIB_DIR}/${filename}" ]; then
+            continue
+        fi
+        compat_log "downloading ${filename}"
+        curl -sSLfo "${COMPAT_LIB_DIR}/${filename}" "${url}"
+    done
+}
+
+# jdeps needs an explicit release for multi-release jars such as slf4j-api.
+compat_multi_release() {
+    java -XshowSettings:properties -version 2>&1 \
+        | awk -F'= *' '/java.specification.version/ { gsub(/[^0-9]/, "", $2); print $2; exit }'
+}
+
+# TestNG class names contained in the test jar, mirroring databend's discovery
+# rules so the generated suite matches what the compat CI runs.
+compat_test_classes() {
+    local test_jar="$1"
+    jar tf "${test_jar}" \
+        | grep '\.class$' \
+        | grep -v '\$' \
+        | sed -e 's/\.class$//' -e 's#/#.#g' \
+        | awk -F. '{
+              name = $NF
+              if (name == "Compatibility" || name == "Utils") next
+              if (name ~ /^Test/ || name ~ /Test$/) print
+          }' \
+        | sort -u
+}

--- a/tests/compatibility/run_release_jar_tests.sh
+++ b/tests/compatibility/run_release_jar_tests.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Runtime gate: run the IT suite the way a release consumer does.
+#
+# Instead of 'mvn test', the locally built shaded driver jar and -tests jar are
+# put on a bare classpath together with the third-party jars downstream compat
+# suites provide, and TestNG is invoked directly. A Databend server must be
+# reachable (tests/Makefile up, or DATABEND_TEST_CONN_PORT pointing elsewhere).
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+COMPAT_GROUPS="${COMPAT_GROUPS:-IT}"
+COMPAT_EXCLUDED_GROUPS="${COMPAT_EXCLUDED_GROUPS:-FLAKY,cluster,MULTI_HOST}"
+
+compat_build_jars
+compat_download_libs
+
+MAIN_JAR="$(compat_main_jar)"
+TEST_JAR="$(compat_test_jar)"
+
+# Keep runs of different group selections in separate directories so a second
+# pass (for example UNIT after IT) does not clobber the first one's report.
+COMPAT_RUN_TAG="$(echo "${COMPAT_GROUPS}" | tr ',[:upper:]' '-[:lower:]')"
+SUITE_FILE="${COMPAT_GENERATED_DIR}/testng-${COMPAT_RUN_TAG}.xml"
+COMPAT_OUTPUT_DIR="${COMPAT_OUTPUT_ROOT}/${COMPAT_RUN_TAG}"
+
+mkdir -p "${COMPAT_GENERATED_DIR}"
+rm -rf "${COMPAT_OUTPUT_DIR}"
+mkdir -p "${COMPAT_OUTPUT_DIR}"
+
+{
+    echo '<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >'
+    echo '<suite name="DatabendJdbcCompatTests" verbose="1" parallel="none">'
+    echo '  <test name="AllTests">'
+    echo '    <groups>'
+    echo '      <run>'
+    for group in $(echo "${COMPAT_GROUPS}" | tr ',' ' '); do
+        echo "        <include name=\"${group}\"/>"
+    done
+    for group in $(echo "${COMPAT_EXCLUDED_GROUPS}" | tr ',' ' '); do
+        echo "        <exclude name=\"${group}\"/>"
+    done
+    echo '      </run>'
+    echo '    </groups>'
+    echo '    <classes>'
+    compat_test_classes "${TEST_JAR}" | while read -r class_name; do
+        echo "      <class name=\"${class_name}\"/>"
+    done
+    echo '    </classes>'
+    echo '  </test>'
+    echo '</suite>'
+} >"${SUITE_FILE}"
+
+# grep -c exits 1 on zero matches, so guard it to keep the message below reachable.
+CLASS_COUNT="$(grep -c '<class name=' "${SUITE_FILE}" || true)"
+if [ "${CLASS_COUNT:-0}" -eq 0 ]; then
+    echo "no test classes discovered in ${TEST_JAR}" >&2
+    exit 1
+fi
+
+compat_log "driver jar: ${MAIN_JAR}"
+compat_log "test jar:   ${TEST_JAR}"
+compat_log "suite:      ${SUITE_FILE} (${CLASS_COUNT} classes, groups=${COMPAT_GROUPS})"
+
+JAVA_ARGS=(-Dlogback.logger.root=INFO)
+if [ -n "${COMPAT_USER_TIMEZONE:-}" ]; then
+    JAVA_ARGS+=("-Duser.timezone=${COMPAT_USER_TIMEZONE}")
+fi
+if [ "${DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT:-}" = "arrow" ]; then
+    # Arrow needs the same JVM openings the arrow-tests Maven profile sets.
+    JAVA_ARGS+=(--add-opens=java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true)
+fi
+
+set +e
+java "${JAVA_ARGS[@]}" \
+    -cp "${COMPAT_LIB_DIR}/*:${MAIN_JAR}:${TEST_JAR}" \
+    org.testng.TestNG -d "${COMPAT_OUTPUT_DIR}" "${SUITE_FILE}"
+EXIT_CODE=$?
+set -e
+
+# TestNG exits 2 when every selected test was skipped; failures stay non-zero.
+if [ "${EXIT_CODE}" -eq 2 ]; then
+    compat_log "TestNG reported only skipped tests"
+    EXIT_CODE=0
+fi
+
+exit "${EXIT_CODE}"

--- a/tests/compatibility/run_release_jar_tests.sh
+++ b/tests/compatibility/run_release_jar_tests.sh
@@ -79,10 +79,23 @@ java "${JAVA_ARGS[@]}" \
 EXIT_CODE=$?
 set -e
 
-# TestNG exits 2 when every selected test was skipped; failures stay non-zero.
-if [ "${EXIT_CODE}" -eq 2 ]; then
-    compat_log "TestNG reported only skipped tests"
-    EXIT_CODE=0
+# TestNG's exit code is a bitmask (org.testng.internal.ExitCode):
+#   1 FAILED, 2 SKIPPED, 4 FAILED_WITHIN_SUCCESS, 8 HAS_NO_TEST.
+# Skips are expected (version-gated and Arrow-gated tests call SkipException), so
+# a skip-only run passes. Everything else must stay non-zero. HAS_NO_TEST matters
+# most here: when a test class cannot be instantiated off the release classpath,
+# TestNG aborts the suite, runs nothing, and reports 8 -- exactly the #414 failure.
+if [ "${EXIT_CODE}" -ne 0 ]; then
+    if [ $((EXIT_CODE & 8)) -ne 0 ]; then
+        compat_log "TestNG ran no tests (exit ${EXIT_CODE}); a test class likely failed to load from the release jars"
+    elif [ $((EXIT_CODE & 1)) -ne 0 ] || [ $((EXIT_CODE & 4)) -ne 0 ]; then
+        compat_log "TestNG reported failures (exit ${EXIT_CODE})"
+    elif [ "${EXIT_CODE}" -eq 2 ]; then
+        compat_log "TestNG reported skipped tests and no failures, treating as success"
+        EXIT_CODE=0
+    else
+        compat_log "TestNG exited ${EXIT_CODE}"
+    fi
 fi
 
 exit "${EXIT_CODE}"


### PR DESCRIPTION
## Problem

databend's compat CI does not use Maven to run our tests. It downloads the released
shaded driver jar and the `-tests` jar, puts them on a bare classpath, and drives
TestNG directly.

`mvn test` cannot reproduce that setup. Maven's test classpath exposes dependencies
that the shaded jar relocates or drops entirely, so test code importing Jackson or
Guava compiles and passes on main, then fails the moment the `-tests` jar runs against
the shaded driver jar.

That is how #414 happened: the breakage surfaced only after the release, blocked
databend CI, and needed a hotfix release to clear. Cutting a release to fix a test-only
problem is the part worth preventing.

## Change

Two gates that run the release-jar layout against the working tree, in `tests/compatibility/`:

- `check_test_jar_deps.sh` — static, no server required. `jdeps` must resolve every
  class the `-tests` jar references using only the shaded driver jar, the JDK, and the
  third-party jars downstream compat suites provide. It also rejects references to
  shade-relocated packages (`com.databend.jdbc.com.fasterxml.jackson`,
  `com.google.shaded.common`, ...) — those resolve, but they are an unstable
  implementation detail of the shaded jar.
- `run_release_jar_tests.sh` — runtime. Discovers test classes from the jar using the
  same rules as databend's `noxfile.py`, generates a TestNG suite, and runs it off a
  bare classpath instead of Maven.

Exposed as `make compat-check` and `make compat-test`, plus a `Compatibility Test`
workflow on every PR. **The existing `mvn test` workflows are unchanged.**

One gap worth calling out: databend's compat CI only selects `groups=IT`, but #414 broke
UNIT-group classes, which an IT-only run never loads. The static check covers every
class in the jar regardless of group, and the workflow adds a UNIT pass for runtime
coverage.

## Testing

Verified against a git worktree at `2ff10f2^`, the commit #414 fixed:

- static gate exits 1 and names all five bad references, including the `ObjectMapper`
  and `MoreExecutors` imports that #414 removed
- runtime gate exits 8 with `An error occurred while instantiating class
  com.databend.jdbc.TestPreparedStatementBytes: com/fasterxml/jackson/databind/ObjectMapper`
  — the same failure databend CI hit
- both pass clean on current main
- also confirmed the relocated-package rule fires, by packing a probe class importing
  `com.databend.jdbc.com.fasterxml.jackson.databind.ObjectMapper` into a copy of the jar
- confirmed a `jdeps` invocation failure is reported as a failure rather than a clean pass
- `mvn checkstyle:check` clean

Docker was unavailable locally, so the runtime gate's 3 failures out of 129 were
connection errors against `localhost:8000`, not classpath problems. The other 126 ran
clean off the bare release classpath. The server-dependent path gets its first real
exercise in this PR's CI.
