### PR TITLE
test: harden release-jar compatibility harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,12 @@ make compat-test
 ```
 
 Both build the jars first. Set `COMPAT_SKIP_BUILD=1` to reuse whatever is already in
-`databend-jdbc/target`. `compat-test` accepts `COMPAT_GROUPS` and
+`databend-jdbc/target`. Like the source build, these targets require JDK 11 or newer.
+`compat-test` accepts `COMPAT_GROUPS` and
 `COMPAT_EXCLUDED_GROUPS` (defaults `IT` and `FLAKY,cluster,MULTI_HOST`) and honours
-`DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT=arrow`. Reports land in
+`DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT=arrow`. It defaults the JVM timezone to
+`Asia/Shanghai`, matching databend's compat CI; set `COMPAT_USER_TIMEZONE` to override
+it. Reports land in
 `tests/compatibility/test-output/<groups>/`, one directory per group selection, so an
 IT pass and a UNIT pass do not overwrite each other:
 

--- a/tests/compatibility/check_test_jar_deps.sh
+++ b/tests/compatibility/check_test_jar_deps.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
+compat_require_java
 compat_build_jars
 compat_download_libs
 

--- a/tests/compatibility/common.sh
+++ b/tests/compatibility/common.sh
@@ -89,10 +89,42 @@ compat_download_libs() {
     done
 }
 
+# Convert java.specification.version to a major version. Java 8 reports "1.8",
+# while newer releases report a single number such as "11" or "17".
+compat_java_major_version() {
+    local specification_version="${1:-}"
+    if [ -z "${specification_version}" ]; then
+        specification_version="$(java -XshowSettings:properties -version 2>&1 \
+            | awk -F'= *' '/java.specification.version/ { gsub(/[[:space:]]/, "", $2); print $2; exit }')"
+    fi
+
+    case "${specification_version}" in
+        1.*)
+            specification_version="${specification_version#1.}"
+            echo "${specification_version%%.*}"
+            ;;
+        *) echo "${specification_version%%.*}" ;;
+    esac
+}
+
+compat_require_java() {
+    local major_version
+    major_version="$(compat_java_major_version)"
+    case "${major_version}" in
+        ''|*[!0-9]*)
+            echo "could not determine the Java major version" >&2
+            return 1
+            ;;
+    esac
+    if [ "${major_version}" -lt 11 ]; then
+        echo "release-jar compatibility tests require JDK 11 or newer (found Java ${major_version})" >&2
+        return 1
+    fi
+}
+
 # jdeps needs an explicit release for multi-release jars such as slf4j-api.
 compat_multi_release() {
-    java -XshowSettings:properties -version 2>&1 \
-        | awk -F'= *' '/java.specification.version/ { gsub(/[^0-9]/, "", $2); print $2; exit }'
+    compat_java_major_version
 }
 
 # TestNG class names contained in the test jar, mirroring databend's discovery
@@ -100,13 +132,13 @@ compat_multi_release() {
 compat_test_classes() {
     local test_jar="$1"
     jar tf "${test_jar}" \
-        | grep '\.class$' \
-        | grep -v '\$' \
-        | sed -e 's/\.class$//' -e 's#/#.#g' \
-        | awk -F. '{
-              name = $NF
+        | awk '/\.class$/ && index($0, "$") == 0 {
+              sub(/\.class$/, "")
+              gsub(/\//, ".")
+              count = split($0, parts, ".")
+              name = parts[count]
               if (name == "Compatibility" || name == "Utils") next
-              if (name ~ /^Test/ || name ~ /Test$/) print
+              if (name ~ /^Test/ || name ~ /Test$/) print $0
           }' \
         | sort -u
 }

--- a/tests/compatibility/run_release_jar_tests.sh
+++ b/tests/compatibility/run_release_jar_tests.sh
@@ -12,7 +12,9 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 COMPAT_GROUPS="${COMPAT_GROUPS:-IT}"
 COMPAT_EXCLUDED_GROUPS="${COMPAT_EXCLUDED_GROUPS:-FLAKY,cluster,MULTI_HOST}"
+COMPAT_USER_TIMEZONE="${COMPAT_USER_TIMEZONE:-Asia/Shanghai}"
 
+compat_require_java
 compat_build_jars
 compat_download_libs
 
@@ -21,11 +23,30 @@ TEST_JAR="$(compat_test_jar)"
 
 # Keep runs of different group selections in separate directories so a second
 # pass (for example UNIT after IT) does not clobber the first one's report.
-COMPAT_RUN_TAG="$(echo "${COMPAT_GROUPS}" | tr ',[:upper:]' '-[:lower:]')"
+COMPAT_RUN_TAG="$(printf '%s' "${COMPAT_GROUPS}" \
+    | tr ',[:upper:]' '-[:lower:]' \
+    | tr -c 'a-z0-9_-' '-')"
+if [ -z "${COMPAT_RUN_TAG}" ]; then
+    COMPAT_RUN_TAG="all"
+fi
 SUITE_FILE="${COMPAT_GENERATED_DIR}/testng-${COMPAT_RUN_TAG}.xml"
 COMPAT_OUTPUT_DIR="${COMPAT_OUTPUT_ROOT}/${COMPAT_RUN_TAG}"
 
+TEST_CLASSES="$(compat_test_classes "${TEST_JAR}")"
+if [ -z "${TEST_CLASSES}" ]; then
+    echo "no test classes discovered in ${TEST_JAR}" >&2
+    exit 1
+fi
+CLASS_COUNT="$(printf '%s\n' "${TEST_CLASSES}" | wc -l | tr -d '[:space:]')"
+
 mkdir -p "${COMPAT_GENERATED_DIR}"
+case "${COMPAT_OUTPUT_DIR}" in
+    "${COMPAT_OUTPUT_ROOT}/"*) ;;
+    *)
+        echo "refusing to clean output directory outside ${COMPAT_OUTPUT_ROOT}: ${COMPAT_OUTPUT_DIR}" >&2
+        exit 1
+        ;;
+esac
 rm -rf "${COMPAT_OUTPUT_DIR}"
 mkdir -p "${COMPAT_OUTPUT_DIR}"
 
@@ -44,7 +65,7 @@ mkdir -p "${COMPAT_OUTPUT_DIR}"
     echo '      </run>'
     echo '    </groups>'
     echo '    <classes>'
-    compat_test_classes "${TEST_JAR}" | while read -r class_name; do
+    printf '%s\n' "${TEST_CLASSES}" | while read -r class_name; do
         echo "      <class name=\"${class_name}\"/>"
     done
     echo '    </classes>'
@@ -52,21 +73,11 @@ mkdir -p "${COMPAT_OUTPUT_DIR}"
     echo '</suite>'
 } >"${SUITE_FILE}"
 
-# grep -c exits 1 on zero matches, so guard it to keep the message below reachable.
-CLASS_COUNT="$(grep -c '<class name=' "${SUITE_FILE}" || true)"
-if [ "${CLASS_COUNT:-0}" -eq 0 ]; then
-    echo "no test classes discovered in ${TEST_JAR}" >&2
-    exit 1
-fi
-
 compat_log "driver jar: ${MAIN_JAR}"
 compat_log "test jar:   ${TEST_JAR}"
 compat_log "suite:      ${SUITE_FILE} (${CLASS_COUNT} classes, groups=${COMPAT_GROUPS})"
 
-JAVA_ARGS=(-Dlogback.logger.root=INFO)
-if [ -n "${COMPAT_USER_TIMEZONE:-}" ]; then
-    JAVA_ARGS+=("-Duser.timezone=${COMPAT_USER_TIMEZONE}")
-fi
+JAVA_ARGS=("-Duser.timezone=${COMPAT_USER_TIMEZONE}")
 if [ "${DATABEND_JDBC_TEST_QUERY_RESULT_FORMAT:-}" = "arrow" ]; then
     # Arrow needs the same JVM openings the arrow-tests Maven profile sets.
     JAVA_ARGS+=(--add-opens=java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true)


### PR DESCRIPTION
## Problem

The release-jar compatibility harness added in #418 correctly catches dependency
leaks, but follow-up review found several gaps in its diagnostics and fidelity:

- an empty test jar exits through `pipefail` before the intended error and leaves a
  partial TestNG suite
- the default JVM timezone differs from databend's downstream compatibility runner
- Java 8 is parsed as version 18 instead of producing a clear unsupported-JDK error
- an unused logback property is passed to TestNG

The group selection also feeds an output-directory name that is recursively cleaned,
so it should not be able to escape the compatibility output root.

## Change

- collect test classes before writing the TestNG suite, and fail with a clear error
  without leaving a partial XML file when none are found
- use one `awk` pass for class discovery so an empty match set remains a valid result
- default `COMPAT_USER_TIMEZONE` to `Asia/Shanghai`, matching databend's `noxfile.py`
- parse both legacy `1.8` and modern Java version formats, require JDK 11+ explicitly,
  and document that requirement
- remove the ineffective logback JVM property
- sanitize group selections used as output tags and verify recursive cleanup remains
  below `tests/compatibility/test-output`

## Testing

- `bash -n tests/compatibility/common.sh tests/compatibility/check_test_jar_deps.sh tests/compatibility/run_release_jar_tests.sh`
- Java version parser checks for `1.8`, `1.8.0`, `11`, and `17.0`
- empty test-jar fixture exits 1 with `no test classes discovered` and creates no
  `testng-it.xml`
- traversal-shaped `COMPAT_GROUPS` produces an output directory below
  `tests/compatibility/test-output`
- `COMPAT_SKIP_BUILD=1 ./tests/compatibility/check_test_jar_deps.sh`
- `mvn -B -ntp checkstyle:check`

## Risk

Low. The changes are limited to the compatibility test harness and its documentation.
The regular Maven test workflows and published driver artifacts are unchanged.
