### PR TITLE
test: verify compatibility gate rejects leaked dependency

### DIFF
--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestPreparedStatementBytes.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestPreparedStatementBytes.java
@@ -1,5 +1,6 @@
 package com.databend.jdbc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import okhttp3.OkHttpClient;
@@ -18,7 +19,13 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class TestPreparedStatementBytes {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final byte[] BINARY_VALUE = new byte[]{0x00, (byte) 0xff, 0x27, 0x61, 0x5c};
+
+    @Test(groups = {"UNIT"})
+    public void testMavenClasspathProvidesJackson() throws Exception {
+        Assert.assertEquals(OBJECT_MAPPER.readTree("{\"value\":1}").get("value").asInt(), 1);
+    }
 
     @Test(groups = {"UNIT"})
     public void testSetBytesUsesHexLiteralByDefault() throws Exception {


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE.** This is an intentional negative test for the compatibility CI
> added in #418 and hardened in #419.

## Problem

We want to verify end to end that the regular Maven test workflow can pass while the
release-jar compatibility workflow rejects a test dependency that is unavailable on
the downstream bare classpath.

## Change

Deliberately reintroduce the #414 failure mode in `TestPreparedStatementBytes`:

- import Jackson's `ObjectMapper` from the Maven test classpath
- initialize it in a static field so the UNIT release-jar run also fails while loading
  the class
- add a small UNIT test proving the dependency works under Maven

The shaded driver relocates Jackson, and the downstream compatibility classpath does
not provide the original `com.fasterxml.jackson` packages. Therefore this change is
expected to pass regular Maven tests and fail the release-jar gates.

## Expected CI

- regular `test`: **pass**
- `Run Checkstyle`: **pass**
- `Test jar resolves on release classpath`: **fail**, reporting
  `TestPreparedStatementBytes -> com.fasterxml.jackson.databind.ObjectMapper`
- release-jar UNIT pass: **fail** while loading `TestPreparedStatementBytes`

## Local validation

- `mvn -B -ntp -pl databend-jdbc -Dtest=TestPreparedStatementBytes#testMavenClasspathProvidesJackson test` — passed
- shaded driver and test-jar packaging — passed
- `./tests/compatibility/check_test_jar_deps.sh` — failed as expected with exit 1,
  naming both `ObjectMapper` and `JsonNode`

## Risk

This PR is intentionally broken and must be closed without merging after the CI result
is confirmed.
